### PR TITLE
feat(teams): integrate nuLiga lineups and results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@
 Eine Homepage für die Schachfreunde HN-Biberach inkl. Blog auf Basis von [Nuxt UI Pro](https://ui.nuxt.com/pro).
 
 Die Seite ist in einem frühen Stadium, weitere Details folgen.
+
+## nuLiga und Cloudflare-Speicher
+
+Mannschaftsaufstellungen und Ergebnisse werden serverseitig von nuLiga geladen und sechs Stunden zwischengespeichert. Lokal nutzt die Anwendung dafür `.data/nuliga-cache`.
+
+Der produktive Cloudflare Worker deklariert zwei Bindings:
+
+- `DB`: eine D1-Datenbank, die Nuxt Content für dynamische Inhaltsabfragen benötigt. Die Inhalte bleiben in Git; D1 enthält den daraus erzeugten Laufzeitindex.
+- `NULIGA_CACHE`: ein KV-Namespace für den persistenten nuLiga-Cache.
+
+Wrangler provisioniert fehlende Ressourcen beim ersten Deployment automatisch und verknüpft sie mit dem Worker. Account-spezifische Ressourcen-IDs oder zusätzliche Build-Umgebungsvariablen sind dafür nicht erforderlich. Nach dem ersten Deployment sollten beide Bindings im Cloudflare-Dashboard beim Worker sichtbar sein.

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,4 +1,4 @@
-import type { ButtonProps } from '@nuxt/ui'
+import type { ButtonProps, CommandPaletteGroup, ContentSearchLink } from '@nuxt/ui'
 
 export default defineAppConfig({
   app: {
@@ -127,6 +127,77 @@ export default defineAppConfig({
           ],
         },
       ],
+    },
+
+    search: {
+      title: 'Suche',
+      description: 'Durchsuche die Inhalte der Schachfreunde Heilbronn-Biberach.',
+      placeholder: 'Inhalte durchsuchen …',
+      resultLimit: 25,
+      links: [
+        {
+          label: 'Startseite',
+          to: '/',
+          icon: 'i-ph-house-duotone',
+        },
+        {
+          label: 'Blog',
+          to: '/blog',
+          icon: 'i-ph-newspaper',
+        },
+        {
+          label: 'Mannschaften',
+          to: '/mannschaften',
+          icon: 'i-ph-castle-turret-duotone',
+        },
+        {
+          label: 'Turniere',
+          to: '/turniere',
+          icon: 'i-ph-trophy-duotone',
+        },
+      ] satisfies ContentSearchLink[],
+      groups: [
+        {
+          id: 'legal-search',
+          label: 'Rechtliches',
+          items: [
+            {
+              label: 'Impressum',
+              to: '/impressum',
+              icon: 'i-ph-file-text-duotone',
+            },
+            {
+              label: 'Datenschutz',
+              to: '/datenschutz',
+              icon: 'i-ph-shield-duotone',
+            },
+          ],
+        },
+        {
+          id: 'external-search',
+          label: 'Externe Links',
+          items: [
+            {
+              label: 'Unterländer Schachtage',
+              to: 'https://www.unterlaender-schachtage.de/',
+              target: '_blank',
+              icon: 'i-ph-crown-duotone',
+            },
+            {
+              label: 'Aktuelle DWZ-Liste',
+              to: 'https://schach.in/zahlen/C0652/',
+              target: '_blank',
+              icon: 'i-ph-chart-bar-duotone',
+            },
+            {
+              label: 'Google Vereinskalender',
+              to: 'https://calendar.google.com/calendar/embed?src=dimi.triantafillidis%40web.de&ctz=Europe%2FBerlin',
+              target: '_blank',
+              icon: 'i-ph-calendar-duotone',
+            },
+          ],
+        },
+      ] satisfies CommandPaletteGroup[],
     },
 
     date: {

--- a/app/app.vue
+++ b/app/app.vue
@@ -27,13 +27,6 @@ useSeoMeta({
   description: 'Schachfreunde Heilbronn-Biberach 1978 e. V. - Der Schachverein im Heilbronner Stadtteil Biberach',
   robots: 'index, follow',
 })
-
-const { searchTerm, groups } = useNavigation()
-
-const [{ data: navigation }, { data: files }] = await Promise.all([
-  useFetch('/api/navigation.json'),
-  useFetch('/api/search.json', { server: false }),
-])
 </script>
 
 <template>
@@ -46,15 +39,7 @@ const [{ data: navigation }, { data: files }] = await Promise.all([
     </UMain>
     <AppFooter />
 
-    <ClientOnly>
-      <LazyUContentSearch
-        v-model:search-term="searchTerm"
-        :files="files"
-        :navigation="navigation"
-        :groups="groups"
-        :fuse="{ resultLimit: 42 }"
-      />
-    </ClientOnly>
+    <LazyAppSearch />
     <HStudioLoginButton aria-label="Nuxt Studio öffnen" />
     <NuxtPwaAssets />
   </UApp>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2,6 +2,8 @@
 @import "@nuxt/ui";
 
 @theme static {
+  --container-8xl: 90rem;
+
   /* Fonts */
   --font-serif: 'Inter';
   --font-sans: 'Inter';
@@ -48,4 +50,8 @@
   --color-mannschaft-800: var(--color-green-800);
   --color-mannschaft-900: var(--color-green-900);
   --color-mannschaft-950: var(--color-green-950);
+}
+
+:root {
+  --ui-container: var(--container-8xl);
 }

--- a/app/components/AppSearch.client.vue
+++ b/app/components/AppSearch.client.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import type { ContentNavigationItem } from '@nuxt/content'
+import type { CommandPaletteGroup, ContentSearchFile } from '@nuxt/ui'
+
+const appConfig = useAppConfig()
+const { open } = useContentSearch()
+
+const searchTerm = ref('')
+const navigation = shallowRef<ContentNavigationItem[]>([])
+const files = shallowRef<ContentSearchFile[]>([])
+const status = ref<'idle' | 'pending' | 'success' | 'error'>('idle')
+const error = shallowRef<Error>()
+
+let pendingRequest: Promise<void> | undefined
+
+const groups = computed<CommandPaletteGroup[]>(() => {
+  if (!error.value) {
+    return appConfig.app.search.groups
+  }
+
+  return [
+    {
+      id: 'search-error',
+      label: 'Suche nicht verfügbar',
+      ignoreFilter: true,
+      items: [
+        {
+          label: 'Erneut versuchen',
+          description: 'Der Suchindex konnte nicht geladen werden.',
+          icon: 'i-lucide-refresh-cw',
+          onSelect: () => void loadSearchData(),
+        },
+      ],
+    },
+    ...appConfig.app.search.groups,
+  ]
+})
+
+function toError(cause: unknown) {
+  return cause instanceof Error ? cause : new Error(String(cause))
+}
+
+async function loadSearchData() {
+  if (status.value === 'success') {
+    return
+  }
+
+  if (pendingRequest) {
+    return pendingRequest
+  }
+
+  status.value = 'pending'
+  error.value = undefined
+
+  pendingRequest = Promise.all([
+    $fetch<ContentNavigationItem[]>('/api/navigation.json'),
+    $fetch<ContentSearchFile[]>('/api/search.json'),
+  ])
+    .then(([loadedNavigation, loadedFiles]) => {
+      navigation.value = loadedNavigation
+      files.value = loadedFiles
+      status.value = 'success'
+    })
+    .catch((cause: unknown) => {
+      error.value = toError(cause)
+      status.value = 'error'
+      console.error('Failed to load the search index.', error.value)
+    })
+    .finally(() => {
+      pendingRequest = undefined
+    })
+
+  return pendingRequest
+}
+
+watch(open, (isOpen) => {
+  if (isOpen) {
+    void loadSearchData()
+  }
+}, { immediate: true })
+</script>
+
+<template>
+  <UContentSearch
+    v-model:search-term="searchTerm"
+    :title="appConfig.app.search.title"
+    :description="appConfig.app.search.description"
+    :placeholder="appConfig.app.search.placeholder"
+    :links="appConfig.app.search.links"
+    :groups="groups"
+    :files="files"
+    :navigation="navigation"
+    :loading="status === 'pending'"
+    :fuse="{ resultLimit: appConfig.app.search.resultLimit }"
+  />
+</template>

--- a/app/components/team/Competition.vue
+++ b/app/components/team/Competition.vue
@@ -4,6 +4,7 @@ import type { LeagueMatch, LeaguePlayer, LeagueTeamSnapshot } from '../../../sha
 
 const props = defineProps<{
   team: LeagueTeamSnapshot
+  refreshing?: boolean
 }>()
 
 const route = useRoute()
@@ -146,7 +147,12 @@ function outcome(match: LeagueMatch) {
 
       <template #footer>
         <div class="flex flex-wrap items-center justify-between gap-2 text-sm text-muted">
-          <span>Aktualisiert {{ formatLeagueDateTime(team.fetchedAt) }}</span>
+          <span role="status" aria-live="polite" class="flex items-center gap-1.5">
+            <UIcon v-if="refreshing" name="i-lucide-loader-circle" class="size-4 animate-spin" />
+            <span>
+              Aktualisiert {{ formatLeagueDateTime(team.fetchedAt) }}<template v-if="refreshing"> · Neue Daten werden geladen</template>
+            </span>
+          </span>
           <UButton
             :to="team.sourceUrl"
             target="_blank"

--- a/app/components/team/Competition.vue
+++ b/app/components/team/Competition.vue
@@ -1,0 +1,399 @@
+<script setup lang="ts">
+import type { TableColumn, TabsItem } from '@nuxt/ui'
+import type { LeagueMatch, LeaguePlayer, LeagueTeamSnapshot } from '../../../shared/types/league'
+
+const props = defineProps<{
+  team: LeagueTeamSnapshot
+}>()
+
+const route = useRoute()
+const today = getBerlinDateKey()
+const upcomingMatches = computed(() => props.team.matches
+  .filter(match => match.status === 'scheduled')
+  .toSorted((left, right) => left.date.localeCompare(right.date)))
+const completedMatches = computed(() => props.team.matches
+  .filter(match => match.status === 'finished')
+  .toSorted((left, right) => right.date.localeCompare(left.date)))
+const nextMatch = computed(() => upcomingMatches.value.find(match => match.date >= today))
+const starters = computed(() => props.team.players.filter(player => player.role === 'starter'))
+const reserves = computed(() => props.team.players.filter(player => player.role === 'reserve'))
+
+const tabItems = computed<TabsItem[]>(() => [
+  {
+    label: 'Spiele',
+    icon: 'i-ph-calendar-duotone',
+    value: 'matches',
+    slot: 'matches',
+    badge: props.team.matches.length,
+  },
+  {
+    label: 'Aufstellung',
+    icon: 'i-ph-users-three-duotone',
+    value: 'lineup',
+    slot: 'lineup',
+    badge: props.team.players.length,
+  },
+])
+
+const activeTab = computed<string | number>({
+  get: () => route.query.bereich === 'aufstellung' ? 'lineup' : 'matches',
+  set: (value) => {
+    void navigateTo({
+      query: {
+        ...route.query,
+        bereich: value === 'lineup' ? 'aufstellung' : undefined,
+      },
+    }, { replace: true })
+  },
+})
+
+const matchColumns: TableColumn<LeagueMatch>[] = [
+  {
+    accessorKey: 'date',
+    header: 'Datum',
+    meta: { class: { th: 'w-36', td: 'align-top' } },
+  },
+  { id: 'pairing', header: 'Begegnung' },
+  {
+    accessorKey: 'round',
+    header: 'Runde',
+    meta: { class: { th: 'hidden lg:table-cell w-20', td: 'hidden lg:table-cell' } },
+  },
+  {
+    accessorKey: 'result',
+    header: 'Ergebnis',
+    meta: { class: { th: 'text-right w-28', td: 'text-right align-top' } },
+  },
+  {
+    id: 'actions',
+    header: '',
+    meta: { class: { th: 'hidden sm:table-cell w-12', td: 'hidden sm:table-cell text-right' } },
+  },
+]
+
+const playerColumns: TableColumn<LeaguePlayer>[] = [
+  { accessorKey: 'board', header: 'Brett', meta: { class: { th: 'w-20', td: 'font-medium' } } },
+  { accessorKey: 'name', header: 'Spieler' },
+  { accessorKey: 'rating', header: 'DWZ', meta: { class: { th: 'text-right w-24', td: 'text-right' } } },
+  {
+    accessorKey: 'appearances',
+    header: 'Einsätze',
+    meta: { class: { th: 'hidden sm:table-cell text-right w-24', td: 'hidden sm:table-cell text-right' } },
+  },
+  {
+    accessorKey: 'boardPoints',
+    header: 'Brettpunkte',
+    meta: { class: { th: 'hidden md:table-cell text-right w-32', td: 'hidden md:table-cell text-right' } },
+  },
+]
+
+function outcome(match: LeagueMatch) {
+  const value = getMatchOutcome(match, props.team.team.name)
+  if (value === 'win') {
+    return { label: 'Sieg', color: 'success' as const }
+  }
+  if (value === 'loss') {
+    return { label: 'Niederlage', color: 'error' as const }
+  }
+  if (value === 'draw') {
+    return { label: 'Remis', color: 'neutral' as const }
+  }
+  return null
+}
+</script>
+
+<template>
+  <div class="not-prose mt-12 space-y-8">
+    <UCard variant="subtle" :ui="{ body: 'p-0 sm:p-0', footer: 'py-3 sm:py-3' }">
+      <dl class="grid grid-cols-2 divide-x divide-y divide-default sm:grid-cols-4 sm:divide-y-0">
+        <div class="space-y-1 p-4 sm:p-5">
+          <dt class="flex items-center gap-2 text-sm text-muted">
+            <UIcon name="i-ph-trophy-duotone" class="size-4 shrink-0" />
+            Liga
+          </dt>
+          <dd class="font-semibold text-highlighted">
+            {{ team.team.competition ?? 'Mannschaftswettbewerb' }}
+          </dd>
+        </div>
+        <div class="space-y-1 p-4 sm:p-5">
+          <dt class="flex items-center gap-2 text-sm text-muted">
+            <UIcon name="i-ph-calendar-blank-duotone" class="size-4 shrink-0" />
+            Saison
+          </dt>
+          <dd class="font-semibold text-highlighted">
+            {{ team.season }}
+          </dd>
+        </div>
+        <div class="space-y-1 p-4 sm:p-5">
+          <dt class="flex items-center gap-2 text-sm text-muted">
+            <UIcon name="i-ph-users-three-duotone" class="size-4 shrink-0" />
+            Spieler
+          </dt>
+          <dd class="font-semibold text-highlighted">
+            {{ team.players.length }}
+          </dd>
+        </div>
+        <div class="space-y-1 p-4 sm:p-5">
+          <dt class="flex items-center gap-2 text-sm text-muted">
+            <UIcon name="i-ph-calendar-check-duotone" class="size-4 shrink-0" />
+            Spiele
+          </dt>
+          <dd class="font-semibold text-highlighted">
+            {{ team.matches.length }}
+          </dd>
+        </div>
+      </dl>
+
+      <template #footer>
+        <div class="flex flex-wrap items-center justify-between gap-2 text-sm text-muted">
+          <span>Aktualisiert {{ formatLeagueDateTime(team.fetchedAt) }}</span>
+          <UButton
+            :to="team.sourceUrl"
+            target="_blank"
+            color="neutral"
+            variant="link"
+            size="sm"
+            trailing-icon="i-lucide-external-link"
+            label="Quelle: nuLiga"
+          />
+        </div>
+      </template>
+    </UCard>
+
+    <UTabs
+      v-model="activeTab"
+      :items="tabItems"
+      variant="link"
+      :unmount-on-hide="false"
+      :ui="{
+        list: 'w-full border-b border-default',
+        trigger: 'flex-1 sm:flex-none',
+        content: 'pt-8',
+      }"
+    >
+      <template #matches>
+        <div class="space-y-10">
+          <section v-if="nextMatch" aria-labelledby="next-match-heading">
+            <h2 id="next-match-heading" class="mb-4 text-2xl font-bold text-highlighted">
+              Nächstes Spiel
+            </h2>
+            <UCard variant="subtle">
+              <div class="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+                <div class="space-y-2">
+                  <div class="flex flex-wrap items-center gap-2 text-sm text-muted">
+                    <UIcon name="i-ph-calendar-duotone" class="size-5" />
+                    <span>{{ formatLeagueDate(nextMatch.date) }}<template v-if="nextMatch.time">, {{ nextMatch.time }} Uhr</template></span>
+                    <UBadge v-if="nextMatch.round" color="neutral" variant="subtle" :label="`${nextMatch.round}. Runde`" />
+                  </div>
+                  <p class="text-lg font-semibold text-highlighted">
+                    {{ nextMatch.home }} <span class="font-normal text-muted">–</span> {{ nextMatch.away }}
+                  </p>
+                </div>
+                <UBadge
+                  color="primary"
+                  variant="subtle"
+                  :label="nextMatch.home === team.team.name ? 'Heimspiel' : 'Auswärtsspiel'"
+                />
+              </div>
+            </UCard>
+          </section>
+
+          <section aria-labelledby="matches-heading">
+            <div class="mb-6">
+              <h2 id="matches-heading" class="text-2xl font-bold text-highlighted">
+                Spielplan und Ergebnisse
+              </h2>
+              <p class="mt-1 text-sm text-muted">
+                Alle Begegnungen der Saison {{ team.season }}.
+              </p>
+            </div>
+
+            <div v-if="upcomingMatches.length" class="space-y-3">
+              <h3 class="text-lg font-semibold text-highlighted">
+                Kommende Spiele
+              </h3>
+              <ul class="divide-y divide-default overflow-hidden rounded-lg border border-default md:hidden">
+                <li v-for="match in upcomingMatches" :key="match.id" class="space-y-2 p-4">
+                  <div class="flex items-center justify-between gap-3 text-sm text-muted">
+                    <span>{{ formatLeagueDate(match.date) }}<template v-if="match.time">, {{ match.time }} Uhr</template></span>
+                    <UBadge v-if="match.round" color="neutral" variant="subtle" size="sm" :label="`${match.round}. Runde`" />
+                  </div>
+                  <p class="text-sm text-highlighted">
+                    <span :class="match.home === team.team.name ? 'font-semibold' : ''">{{ match.home }}</span>
+                    <span class="mx-1 text-muted">–</span>
+                    <span :class="match.away === team.team.name ? 'font-semibold' : ''">{{ match.away }}</span>
+                  </p>
+                </li>
+              </ul>
+              <UCard class="hidden md:block" variant="subtle" :ui="{ body: 'p-0 sm:p-0' }">
+                <UTable :data="upcomingMatches" :columns="matchColumns">
+                  <template #date-cell="{ row }">
+                    <div class="whitespace-nowrap">
+                      <div>{{ formatLeagueDate(row.original.date) }}</div>
+                      <div v-if="row.original.time" class="text-xs text-muted">
+                        {{ row.original.time }} Uhr
+                      </div>
+                    </div>
+                  </template>
+                  <template #pairing-cell="{ row }">
+                    <span :class="row.original.home === team.team.name ? 'font-semibold text-highlighted' : ''">{{ row.original.home }}</span>
+                    <span class="mx-1 text-muted">–</span>
+                    <span :class="row.original.away === team.team.name ? 'font-semibold text-highlighted' : ''">{{ row.original.away }}</span>
+                  </template>
+                  <template #result-cell>
+                    <span class="text-muted">offen</span>
+                  </template>
+                </UTable>
+              </UCard>
+            </div>
+
+            <div v-if="completedMatches.length" :class="upcomingMatches.length ? 'mt-8' : ''" class="space-y-3">
+              <h3 class="text-lg font-semibold text-highlighted">
+                Ergebnisse
+              </h3>
+              <ul class="divide-y divide-default overflow-hidden rounded-lg border border-default md:hidden">
+                <li v-for="match in completedMatches" :key="match.id" class="space-y-2 p-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="text-sm text-muted">
+                      <div>{{ formatLeagueDate(match.date) }}</div>
+                      <div v-if="match.time" class="text-xs">
+                        {{ match.time }} Uhr
+                      </div>
+                    </div>
+                    <div class="flex flex-col items-end gap-1">
+                      <span class="font-semibold text-highlighted">{{ match.result }}</span>
+                      <UBadge
+                        v-if="outcome(match)"
+                        size="sm"
+                        variant="subtle"
+                        :color="outcome(match)?.color"
+                        :label="outcome(match)?.label"
+                      />
+                    </div>
+                  </div>
+                  <div class="flex items-end justify-between gap-3">
+                    <p class="text-sm text-highlighted">
+                      <span :class="match.home === team.team.name ? 'font-semibold' : ''">{{ match.home }}</span>
+                      <span class="mx-1 text-muted">–</span>
+                      <span :class="match.away === team.team.name ? 'font-semibold' : ''">{{ match.away }}</span>
+                    </p>
+                    <UButton
+                      v-if="match.reportUrl"
+                      :to="match.reportUrl"
+                      target="_blank"
+                      color="neutral"
+                      variant="ghost"
+                      size="sm"
+                      icon="i-lucide-external-link"
+                      aria-label="Spielbericht bei nuLiga öffnen"
+                    />
+                  </div>
+                </li>
+              </ul>
+              <UCard class="hidden md:block" variant="subtle" :ui="{ body: 'p-0 sm:p-0' }">
+                <UTable :data="completedMatches" :columns="matchColumns">
+                  <template #date-cell="{ row }">
+                    <div class="whitespace-nowrap">
+                      <div>{{ formatLeagueDate(row.original.date) }}</div>
+                      <div v-if="row.original.time" class="text-xs text-muted">
+                        {{ row.original.time }} Uhr
+                      </div>
+                    </div>
+                  </template>
+                  <template #pairing-cell="{ row }">
+                    <span :class="row.original.home === team.team.name ? 'font-semibold text-highlighted' : ''">{{ row.original.home }}</span>
+                    <span class="mx-1 text-muted">–</span>
+                    <span :class="row.original.away === team.team.name ? 'font-semibold text-highlighted' : ''">{{ row.original.away }}</span>
+                  </template>
+                  <template #result-cell="{ row }">
+                    <div class="flex flex-col items-end gap-1">
+                      <span class="font-semibold text-highlighted">{{ row.original.result }}</span>
+                      <UBadge
+                        v-if="outcome(row.original)"
+                        size="sm"
+                        variant="subtle"
+                        :color="outcome(row.original)?.color"
+                        :label="outcome(row.original)?.label"
+                      />
+                    </div>
+                  </template>
+                  <template #actions-cell="{ row }">
+                    <UButton
+                      v-if="row.original.reportUrl"
+                      :to="row.original.reportUrl"
+                      target="_blank"
+                      color="neutral"
+                      variant="ghost"
+                      icon="i-lucide-external-link"
+                      aria-label="Spielbericht bei nuLiga öffnen"
+                    />
+                  </template>
+                </UTable>
+              </UCard>
+            </div>
+
+            <UEmpty
+              v-if="!upcomingMatches.length && !completedMatches.length"
+              icon="i-ph-calendar-blank-duotone"
+              title="Keine Spiele verfügbar"
+              description="Für diese Mannschaft sind derzeit keine Spieltermine hinterlegt."
+            />
+          </section>
+        </div>
+      </template>
+
+      <template #lineup>
+        <section aria-labelledby="lineup-heading">
+          <div class="mb-6">
+            <h2 id="lineup-heading" class="text-2xl font-bold text-highlighted">
+              Mannschaftsaufstellung
+            </h2>
+            <p class="mt-1 text-sm text-muted">
+              Gemeldete Spieler und ihre bisherigen Einsätze.
+            </p>
+          </div>
+
+          <div class="space-y-8">
+            <div v-if="starters.length" class="space-y-3">
+              <h3 class="text-lg font-semibold text-highlighted">
+                Stammspieler
+              </h3>
+              <UCard variant="subtle" :ui="{ body: 'p-0 sm:p-0' }">
+                <UTable :data="starters" :columns="playerColumns">
+                  <template #rating-cell="{ row }">
+                    {{ row.original.rating ?? '–' }}
+                  </template>
+                  <template #appearances-cell="{ row }">
+                    {{ row.original.appearances ?? '–' }}
+                  </template>
+                  <template #boardPoints-cell="{ row }">
+                    {{ row.original.boardPoints ?? '–' }}
+                  </template>
+                </UTable>
+              </UCard>
+            </div>
+
+            <div v-if="reserves.length" class="space-y-3">
+              <h3 class="text-lg font-semibold text-highlighted">
+                Ersatzspieler
+              </h3>
+              <UCard variant="subtle" :ui="{ body: 'p-0 sm:p-0' }">
+                <UTable :data="reserves" :columns="playerColumns">
+                  <template #rating-cell="{ row }">
+                    {{ row.original.rating ?? '–' }}
+                  </template>
+                  <template #appearances-cell="{ row }">
+                    {{ row.original.appearances ?? '–' }}
+                  </template>
+                  <template #boardPoints-cell="{ row }">
+                    {{ row.original.boardPoints ?? '–' }}
+                  </template>
+                </UTable>
+              </UCard>
+            </div>
+          </div>
+        </section>
+      </template>
+    </UTabs>
+  </div>
+</template>

--- a/app/composables/useNavigation.ts
+++ b/app/composables/useNavigation.ts
@@ -1,5 +1,3 @@
-import type { CommandPaletteGroup } from '@nuxt/ui'
-import type { ContentSearchItem } from '@nuxt/ui/runtime/types/content.js'
 import { createSharedComposable } from '@vueuse/core'
 
 function _useHeaderLinks() {
@@ -34,27 +32,3 @@ function _useFooterLinks() {
 }
 
 export const useFooterLinks = import.meta.client ? createSharedComposable(_useFooterLinks) : _useFooterLinks
-
-function _useNavigation() {
-  const searchTerm = ref<string>('')
-
-  const { headerLinks } = useHeaderLinks()
-  const { footerLinks } = useFooterLinks()
-
-  const groups = computed<CommandPaletteGroup<ContentSearchItem>[]>(() =>
-    footerLinks.value.map(group => ({
-      id: group.label,
-      label: group.label,
-      items: group.children || [],
-    })),
-  )
-
-  return {
-    searchTerm,
-    headerLinks,
-    footerLinks,
-    groups,
-  }
-}
-
-export const useNavigation = import.meta.client ? createSharedComposable(_useNavigation) : _useNavigation

--- a/app/pages/mannschaften/[slug].vue
+++ b/app/pages/mannschaften/[slug].vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import type { LeagueTeamSnapshot } from '../../../shared/types/league'
+import { isLeagueSnapshotStale } from '#shared/constants/league'
+
+const LEAGUE_REFRESH_DELAYS_MS = [1_000, 2_000, 4_000] as const
 
 definePageMeta({
   heroBackground: 'opacity-50',
@@ -10,8 +13,87 @@ const { data: page } = await usePageContent({
   collection: 'team',
 })
 const leagueEndpoint = computed(() => `/api/teams/${String(route.params.slug)}`)
-const { data: league, error: leagueError, status: leagueStatus } = await useFetch<LeagueTeamSnapshot>(leagueEndpoint, {
+const {
+  data: league,
+  error: leagueError,
+  status: leagueStatus,
+  refresh: refreshLeague,
+} = await useFetch<LeagueTeamSnapshot>(leagueEndpoint, {
   deep: false,
+})
+const leagueRefreshing = ref(false)
+let refreshController: AbortController | undefined
+let stopLeagueWatcher: (() => void) | undefined
+
+function waitForRefresh(delay: number, signal: AbortSignal) {
+  return new Promise<boolean>((resolve) => {
+    if (signal.aborted) {
+      resolve(false)
+      return
+    }
+
+    let timer: ReturnType<typeof setTimeout>
+    const abort = () => {
+      clearTimeout(timer)
+      signal.removeEventListener('abort', abort)
+      resolve(false)
+    }
+
+    timer = setTimeout(() => {
+      signal.removeEventListener('abort', abort)
+      resolve(true)
+    }, delay)
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
+
+async function refreshStaleLeague(initialFetchedAt: string, controller: AbortController) {
+  leagueRefreshing.value = true
+
+  try {
+    for (const delay of LEAGUE_REFRESH_DELAYS_MS) {
+      if (!await waitForRefresh(delay, controller.signal)) {
+        return
+      }
+
+      await refreshLeague()
+
+      if (controller.signal.aborted || !league.value || league.value.fetchedAt !== initialFetchedAt) {
+        return
+      }
+    }
+  }
+  finally {
+    if (refreshController === controller) {
+      leagueRefreshing.value = false
+      refreshController = undefined
+    }
+  }
+}
+
+onMounted(() => {
+  stopLeagueWatcher = watch(
+    [leagueEndpoint, () => league.value?.fetchedAt],
+    ([, fetchedAt]) => {
+      refreshController?.abort()
+      refreshController = undefined
+
+      if (!fetchedAt || !isLeagueSnapshotStale(fetchedAt)) {
+        leagueRefreshing.value = false
+        return
+      }
+
+      const controller = new AbortController()
+      refreshController = controller
+      void refreshStaleLeague(fetchedAt, controller)
+    },
+    { immediate: true },
+  )
+})
+
+onScopeDispose(() => {
+  stopLeagueWatcher?.()
+  refreshController?.abort()
 })
 </script>
 
@@ -19,13 +101,13 @@ const { data: league, error: leagueError, status: leagueStatus } = await useFetc
   <NuxtLayout name="article" collection="team">
     <ContentRenderer v-if="page" :value="page" />
 
-    <div v-if="leagueStatus === 'pending'" class="not-prose mt-12 space-y-4" aria-label="Mannschaftsdaten werden geladen">
+    <div v-if="leagueStatus === 'pending' && !league" class="not-prose mt-12 space-y-4" aria-label="Mannschaftsdaten werden geladen">
       <USkeleton class="h-8 w-48" />
       <USkeleton class="h-32 w-full" />
       <USkeleton class="h-64 w-full" />
     </div>
 
-    <TeamCompetition v-else-if="league" :team="league" />
+    <TeamCompetition v-else-if="league" :team="league" :refreshing="leagueRefreshing" />
 
     <UAlert
       v-else-if="leagueError && page?.league"

--- a/app/pages/mannschaften/[slug].vue
+++ b/app/pages/mannschaften/[slug].vue
@@ -1,15 +1,47 @@
 <script setup lang="ts">
+import type { LeagueTeamSnapshot } from '../../../shared/types/league'
+
 definePageMeta({
   heroBackground: 'opacity-50',
 })
 
+const route = useRoute()
 const { data: page } = await usePageContent({
   collection: 'team',
+})
+const leagueEndpoint = computed(() => `/api/teams/${String(route.params.slug)}`)
+const { data: league, error: leagueError, status: leagueStatus } = await useFetch<LeagueTeamSnapshot>(leagueEndpoint, {
+  deep: false,
 })
 </script>
 
 <template>
   <NuxtLayout name="article" collection="team">
     <ContentRenderer v-if="page" :value="page" />
+
+    <div v-if="leagueStatus === 'pending'" class="not-prose mt-12 space-y-4" aria-label="Mannschaftsdaten werden geladen">
+      <USkeleton class="h-8 w-48" />
+      <USkeleton class="h-32 w-full" />
+      <USkeleton class="h-64 w-full" />
+    </div>
+
+    <TeamCompetition v-else-if="league" :team="league" />
+
+    <UAlert
+      v-else-if="leagueError && page?.league"
+      class="not-prose mt-12"
+      color="warning"
+      variant="subtle"
+      icon="i-ph-warning-circle-duotone"
+      title="Mannschaftsdaten derzeit nicht verfügbar"
+      description="Die aktuellen Daten konnten nicht von nuLiga geladen werden. Bitte versuche es später erneut oder öffne die Quelle direkt."
+      :actions="[{
+        label: 'Bei nuLiga öffnen',
+        to: page.league.groupUrl,
+        target: '_blank',
+        color: 'neutral',
+        variant: 'outline',
+      }]"
+    />
   </NuxtLayout>
 </template>

--- a/app/utils/league.ts
+++ b/app/utils/league.ts
@@ -1,0 +1,56 @@
+import type { LeagueMatch } from '../../shared/types/league'
+
+const dateFormatter = new Intl.DateTimeFormat('de-DE', {
+  weekday: 'short',
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  timeZone: 'Europe/Berlin',
+})
+
+const dateTimeFormatter = new Intl.DateTimeFormat('de-DE', {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  timeZone: 'Europe/Berlin',
+})
+
+export function formatLeagueDate(date: string) {
+  return dateFormatter.format(new Date(`${date}T12:00:00Z`))
+}
+
+export function formatLeagueDateTime(value: string) {
+  return dateTimeFormatter.format(new Date(value))
+}
+
+export function getBerlinDateKey() {
+  const parts = new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'Europe/Berlin',
+  }).formatToParts(new Date())
+  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find(item => item.type === type)?.value
+  return `${part('year')}-${part('month')}-${part('day')}`
+}
+
+export function getMatchOutcome(match: LeagueMatch, teamName: string) {
+  if (!match.result) {
+    return null
+  }
+
+  const scores = match.result.split(':').map(score => Number.parseFloat(score.trim().replace(',', '.')))
+  if (scores.length !== 2 || scores.some(Number.isNaN)) {
+    return null
+  }
+
+  const [homeScore, awayScore] = scores as [number, number]
+  const teamScore = match.home === teamName ? homeScore : awayScore
+  const opponentScore = match.home === teamName ? awayScore : homeScore
+  if (teamScore === opponentScore) {
+    return 'draw'
+  }
+  return teamScore > opponentScore ? 'win' : 'loss'
+}

--- a/content.config.ts
+++ b/content.config.ts
@@ -17,6 +17,13 @@ const siteVariantSchemas = {
   }),
 }
 
+const leagueSchema = z.object({
+  provider: z.literal('nuliga'),
+  season: z.string().min(1),
+  groupUrl: z.url(),
+  teamName: z.string().min(1),
+}).optional()
+
 export default defineContentConfig({
   collections: {
     user: defineCollection({
@@ -60,7 +67,10 @@ export default defineContentConfig({
     team: defineCollection({
       type: 'page',
       source: 'mannschaften/**/*.{md,yaml}',
-      schema: mergeVariantSchemas(['team'], siteVariantSchemas).extend(seo),
+      schema: mergeVariantSchemas(['team'], siteVariantSchemas).extend({
+        ...seo,
+        league: leagueSchema,
+      }),
     }),
 
     tournament: defineCollection({

--- a/content.config.ts
+++ b/content.config.ts
@@ -10,8 +10,20 @@ const seo = {
   robots: defineRobotsSchema(),
 }
 
+const userAvatarSchema = z.object({
+  src: property(z.string()).editor({ input: 'media' }).optional(),
+  alt: z.string().optional(),
+  icon: property(z.string()).editor({ input: 'icon' }).optional(),
+  text: z.string().optional(),
+}).optional()
+
+const userVariantSchema = variantSchemas.user.extend({
+  avatar: userAvatarSchema,
+})
+
 const siteVariantSchemas = {
   ...variantSchemas,
+  user: z.object({}),
   articleTournament: z.object({
     tournament: z.string().optional(),
   }),
@@ -29,7 +41,7 @@ export default defineContentConfig({
     user: defineCollection({
       type: 'data',
       source: 'users/**/*.{md,yaml}',
-      schema: mergeVariantSchemas(['user'], siteVariantSchemas),
+      schema: userVariantSchema,
     }),
 
     landing: defineCollection({
@@ -38,7 +50,7 @@ export default defineContentConfig({
       schema: z.object({
         hero: property(z.object({})).inherit('@nuxt/ui/components/PageSection.vue'),
         cards: z.array(property(z.object({})).inherit('@nuxt/ui/components/PageCard.vue')).optional(),
-      }),
+      }).extend(seo),
     }),
 
     snippet: defineCollection({

--- a/content/blog/article/20170101.dvm-u14-2016.md
+++ b/content/blog/article/20170101.dvm-u14-2016.md
@@ -1,11 +1,14 @@
 ---
+title: DVM U14 2016 in Düsseldorf
 authors:
   - dimitrios-triantafillidis
-title: DVM U14 2016 in Düsseldorf
 category: Jugend
 date: 2017-01-01
-status: archived
 description: Bericht über die Teilnahme unseres Vereins an der DVM U14 2016 in Düsseldorf, mit Einblicken in Spiele und Teamerlebnisse.
+sitemap:
+  loc: /blog/article/dvm-u14-2016
+status: archived
+toc: true
 ---
 
 Alljährlich finden zwischen Weihnachten und Neujahr die Deutschen Vereins-Mannschaftsmeisterschaften (DVM) der Jugend statt. Unser kleiner Verein nimmt in diesem Jahr schon zum 6. Mal daran teil und schickt in 2016 erstmalig eine etwas ältere Jungenmannschaft - die U14 - an den Start. Bisher waren es immer die jüngeren Spieler des Vereins (U10-U12), oder die Mädchen (U14w).
@@ -157,4 +160,4 @@ Im kommenden Jahr dürfen die 5 Jungs erneut in der U14 spielen, und haben es nu
 
 Eine von der DSJ und der Düsseldorfer SK sehr gut organisierte DVM. Die Räumlichkeiten boten sehr gute Spielbedingungen. Die Zimmer waren modern und sehr sauber. Die Siegerehrung war sehr straff und zog sich erfreulicherweise nicht unnötig in die Länge. Somit konnten wir sehr gemütlich unseren Zug Richtung Heimat erwischen und mussten nicht hetzen. Großen Dank an dieser Stelle an Philipp Müller, der sich bereit erklärt hatte, als Trainer vor Ort mitzureisen und die Jungs immer top vorbereitet ans Brett schickte. Unter dem Strich bekommt diese DVM die Note sehr gut.
 
-Auf der [offiziellen Seite der DSJ](http://www.deutsche-schachjugend.de/2016/dvm-u14/) gibt es alle Ergebnisse zum nachlesen und natürlich alle Partien auch zum Nachspielen.[](http://schachjugend-baden.de/2018/03/darja-fischer-gewinnt-die-u10-bw-blitzmeisterschaft/)
+Auf der [offiziellen Seite der DSJ](http://www.deutsche-schachjugend.de/2016/dvm-u14/) gibt es alle Ergebnisse zum nachlesen und natürlich alle Partien auch zum Nachspielen.

--- a/content/blog/article/20170331.ergebnisse-6-biberach-jugend-pokalturnier.md
+++ b/content/blog/article/20170331.ergebnisse-6-biberach-jugend-pokalturnier.md
@@ -5,7 +5,10 @@ authors:
 category: Jugend
 date: 2017-03-31
 description: Ergebnisse des 6. Biberacher Jugend-Pokalturniers 2017, Altersklassen U8-U12.
+sitemap:
+  loc: /blog/article/ergebnisse-6-biberach-jugend-pokalturnier
 status: archived
+toc: true
 ---
 
 ## Altersklasse U8 + U10

--- a/content/blog/article/20170402.ergebnisse-7-biber-jugend-cup.md
+++ b/content/blog/article/20170402.ergebnisse-7-biber-jugend-cup.md
@@ -1,9 +1,12 @@
 ---
-title: '7. Biber-Jugend-Cup 2017: Ergebnisse'
+title: "7. Biber-Jugend-Cup 2017: Ergebnisse"
 category: Jugend
 date: 2017-04-02
 description: Ergebnisse des 7. Biber-Jugend-Cups 2017, Altersklassen U8-U25 in aufsteigender Reihenfolge sortiert.
+sitemap:
+  loc: /blog/article/ergebnisse-7-biber-jugend-cup
 status: archived
+toc: true
 tournament: biber-jugend-cup
 ---
 

--- a/content/blog/article/20180304.biber-jugend-cup-pokal.md
+++ b/content/blog/article/20180304.biber-jugend-cup-pokal.md
@@ -2,8 +2,11 @@
 title: Erfolgreiche Ausrichtung des Biber-Jugend-Cups und des Biber-Jugend-Pokals 2018
 category: Jugend
 date: 2018-03-04
-description: 'Eindrücke vom Biber-Jugend-Cup und -Pokal 2018: Eine Zusammenfassung der Höhepunkte, Teilnehmererfolge und organisatorischen Herausforderungen eines bemerkenswerten Schachevents.'
+description: "Eindrücke vom Biber-Jugend-Cup und -Pokal 2018: Eine Zusammenfassung der Höhepunkte, Teilnehmererfolge und organisatorischen Herausforderungen eines bemerkenswerten Schachevents."
+sitemap:
+  loc: /blog/article/biber-jugend-cup-pokal
 status: archived
+toc: true
 tournament: biber-jugend-cup
 ---
 

--- a/content/blog/article/20180325.bw-jugendblitzmeisterschaft.md
+++ b/content/blog/article/20180325.bw-jugendblitzmeisterschaft.md
@@ -2,8 +2,11 @@
 title: BW-Jugendblitzmeisterschaft 2018
 category: Jugend
 date: 2018-03-25
-description: 'Erfolgreiche Bilanz der Biberacher Schachtalente bei den BW-Blitzmeisterschaften: Titelgewinn, Vizemeistertitel und starke Einzelleistungen in verschiedenen Altersklassen.'
+description: "Erfolgreiche Bilanz der Biberacher Schachtalente bei den BW-Blitzmeisterschaften: Titelgewinn, Vizemeistertitel und starke Einzelleistungen in verschiedenen Altersklassen."
+sitemap:
+  loc: /blog/article/bw-jugendblitzmeisterschaft
 status: archived
+toc: true
 ---
 
 In der U10 landete Rodrigo Melzig in einem starken Teilnehmerfeld mit 10 Punkten aus 14 Runden auf dem 5. Platz. Lediglich ein halber Punkt trennte ihn vom 3. Platz.

--- a/content/blog/article/20180501.wvmm-2018.md
+++ b/content/blog/article/20180501.wvmm-2018.md
@@ -2,8 +2,11 @@
 title: WVMM 2018
 category: Jugend
 date: 2018-05-01
-description: 'Erfolgreiche Teilnahme in allen Altersklassen: U16 sichert sich Vizemeistertitel und Qualifikation für die Deutsche Meisterschaft.'
+description: "Erfolgreiche Teilnahme in allen Altersklassen: U16 sichert sich Vizemeistertitel und Qualifikation für die Deutsche Meisterschaft."
+sitemap:
+  loc: /blog/article/wvmm-2018
 status: archived
+toc: true
 ---
 
 Die Württembergischen Vereinsmeisterschaften der Jugend 2018 fanden am Samstag, den 21. April 2018 in Schwäbisch Gmünd statt. Dabei konnte unser Verein in jeder Altersklasse eine Mannschaft stellen. Lediglich drei weitere Vereine in Württemberg konnten das den Biberachern nachmachen. Aus dem Unterländer Schachbezirk schickten leider nur 3 Vereine (SF Biberach, Heilbronner SchV, SF Kornwestheim) Teams ins Rennen. Nicht gerade ein tolles Zeugnis der Unterländer Vereine.

--- a/content/blog/article/20180704.bw-mannschaftsfinale-u16.md
+++ b/content/blog/article/20180704.bw-mannschaftsfinale-u16.md
@@ -3,7 +3,10 @@ title: BW-Mannschaftsfinale U16 2018
 category: Jugend
 date: 2018-07-04
 description: Biberacher U16 zeigt starke Leistung und belegt den 3. Platz beim BW-Finale.
+sitemap:
+  loc: /blog/article/bw-mannschaftsfinale-u16
 status: archived
+toc: true
 ---
 
 Gespielt wurde in toller Location, in Ortenberg (die Jugendherberge war mal ein Schloss).

--- a/content/blog/article/20190310.ergebnisse-8-biberach-jugend-pokalturnier.md
+++ b/content/blog/article/20190310.ergebnisse-8-biberach-jugend-pokalturnier.md
@@ -1,9 +1,12 @@
 ---
-title: '8. Biberacher Jugend-Pokalturnier 2019: Ergebnisse'
+title: "8. Biberacher Jugend-Pokalturnier 2019: Ergebnisse"
 category: Jugend
 date: 2019-03-10
 description: Ergebnisse des 8. Biberacher Jugend-Pokalturniers 2019, Altersklassen U8-U12.
+sitemap:
+  loc: /blog/article/ergebnisse-8-biberach-jugend-pokalturnier
 status: archived
+toc: true
 ---
 
 ## Altersklasse U8 + U10

--- a/content/blog/article/20190311.ergebnisse-9-biber-jugend-cup.md
+++ b/content/blog/article/20190311.ergebnisse-9-biber-jugend-cup.md
@@ -1,9 +1,12 @@
 ---
-title: '9. Biber-Jugend-Cup 2019: Ergebnisse'
+title: "9. Biber-Jugend-Cup 2019: Ergebnisse"
 category: Jugend
 date: 2019-03-11
 description: Ergebnisse des 9. Biber-Jugend-Cups 2019, Altersklassen U8-U25 in aufsteigender Reihenfolge sortiert.
+sitemap:
+  loc: /blog/article/ergebnisse-9-biber-jugend-cup
 status: archived
+toc: true
 tournament: biber-jugend-cup
 ---
 

--- a/content/blog/article/20190312.lizenzverlängerung-in-ruit.md
+++ b/content/blog/article/20190312.lizenzverlängerung-in-ruit.md
@@ -2,8 +2,11 @@
 title: Lizenzverlängerung B- und C-Trainer in Ruit
 category: Verein
 date: 2019-03-12
-description: 'Fortbildungsinitiative des Heilbronn-Biberach Schachvereins: Mitglieder Armin und Philipp erneuern ihre Trainerlizenzen in Ruit und Köln.'
+description: "Fortbildungsinitiative des Heilbronn-Biberach Schachvereins: Mitglieder Armin und Philipp erneuern ihre Trainerlizenzen in Ruit und Köln."
+sitemap:
+  loc: /blog/article/lizenzverlangerung-in-ruit
 status: archived
+toc: true
 ---
 
 Unser Mitglied Armin hat neben 20 anderen Trainern an der Fortbildungsveranstaltung teilgenommen, in der die B- und C-Trainerlizenzen verlängert werden konnten. Die Veranstaltung fan an der Sportschule in Ruit statt.

--- a/content/blog/article/20190313.9-biber-jugend-cup-dank-und-ausblick.md
+++ b/content/blog/article/20190313.9-biber-jugend-cup-dank-und-ausblick.md
@@ -2,8 +2,11 @@
 title: 9. Biber-Jugend-Cup - Dank und Ausblick
 category: Jugend
 date: 2019-03-13
-description: 'Erfolgreicher 9. Biber-Jugend-Cup: Rekordbeteiligung und herzlicher Dank an Helfer und Sponsoren – Vorfreude auf die 10. Ausgabe im Jahr 2020.'
+description: "Erfolgreicher 9. Biber-Jugend-Cup: Rekordbeteiligung und herzlicher Dank an Helfer und Sponsoren – Vorfreude auf die 10. Ausgabe im Jahr 2020."
+sitemap:
+  loc: /blog/article/9-biber-jugend-cup-dank-und-ausblick
 status: archived
+toc: true
 tournament: biber-jugend-cup
 ---
 

--- a/content/blog/article/20190403.biberach-holt-meistertitel.md
+++ b/content/blog/article/20190403.biberach-holt-meistertitel.md
@@ -3,7 +3,10 @@ title: WVMM 2019 - Biberach holt Meistertitel
 category: Jugend
 date: 2019-04-03
 description: Biberachs Jugendteams glänzen bei den Württembergischen Mannschaftsmeisterschaften in Göppingen, mit einem spektakulären Meistertitel in der U14 und einem beeindruckenden zweiten Platz in der U16.
+sitemap:
+  loc: /blog/article/biberach-holt-meistertitel
 status: archived
+toc: true
 ---
 
 Bei den Württembergischen Mannschaftsmeisterschaften in Göppingen überzeugten die drei Jugendteams des Biberacher Schachklubs:
@@ -22,7 +25,7 @@ Eine Sekunde war letztlich das Zünglein an der Waage: beim Stande von 0,5 – 1
 
 Zur großen Freude Kornwestheimer natürlich, dies das Duell dann doch etwas zu hoch mit 3,5-0,5 für sich entscheiden konnten. Biberach wurde Zweiter, nahm es sportlich und freut sich schon jetzt auf die Stichkämpfe gegen die Badener Vereine.
 
-Komplettiert wurde das gute Abschneiden durch einen 6. Platz in der U12, punktgleich mit Rang 4. Das Resultat ist bemerkenswert, da die Mannschaft auch  aus unerfahreneren U8- und U10-Spielern bestand, die an den Turniersport gerade herangeführt werden.
+Komplettiert wurde das gute Abschneiden durch einen 6. Platz in der U12, punktgleich mit Rang 4. Das Resultat ist bemerkenswert, da die Mannschaft auch aus unerfahreneren U8- und U10-Spielern bestand, die an den Turniersport gerade herangeführt werden.
 
 Einzelheiten erfahrt ihr im umfangreichen [Bericht von Dimi](/assets/blog/20190403.biberach-holt-meistertitel/190330-WVMM-in-Goeppingen.pdf){external="" target="_blank"}.
 

--- a/content/blog/article/20190627.jugendopen-untergrombach-2019.md
+++ b/content/blog/article/20190627.jugendopen-untergrombach-2019.md
@@ -5,7 +5,10 @@ authors:
 category: Jugend
 date: 2019-06-27
 description: 2 Biberacher Teilnehmer beim Jugendopen in Untergrombach
+sitemap:
+  loc: /blog/article/jugendopen-untergrombach-2019
 status: archived
+toc: true
 ---
 
 ![Untergrombach 2019](/assets/blog/20190627.jugendopen-untergrombach-2019/ugrombach2019_3.png)

--- a/content/blog/article/20190714.karlsruher-jugend-open-2019.md
+++ b/content/blog/article/20190714.karlsruher-jugend-open-2019.md
@@ -3,7 +3,10 @@ title: Karlsruher Jugend-Open 2019
 category: Jugend
 date: 2019-07-14
 description: 5 Biber beim Turnier in Karlsruhe
+sitemap:
+  loc: /blog/article/karlsruher-jugend-open-2019
 status: archived
+toc: true
 ---
 
 Mit fünf Kinder in 3 Altersklassen fuhren wir zum 10.Karlsruher Jugendopen. Dieses ist schon letztes Jahr aus dem engen und überfüllten Anne-Frank-Haus in ein besseres Ambiente gezogen, bei dem die Bedingungen deutlich besser sind und genug Platz für ca 200 Kinder bietet.

--- a/content/blog/article/20191012.jugendbundesliga-sued.md
+++ b/content/blog/article/20191012.jugendbundesliga-sued.md
@@ -2,8 +2,11 @@
 title: Jugendbundesliga Süd 2019/20 (Karlsruher SF 1)
 category: Jugend
 date: 2019-10-12
-description: 'Herausforderung gegen den Titelverteidiger: Biberacher Jugend zeigt Kampfgeist trotz Niederlage in der Jugendbundesliga Süd.'
+description: "Herausforderung gegen den Titelverteidiger: Biberacher Jugend zeigt Kampfgeist trotz Niederlage in der Jugendbundesliga Süd."
+sitemap:
+  loc: /blog/article/jugendbundesliga-sued
 status: archived
+toc: true
 ---
 
 Doch schon früh zeigte sich an einigen Brettern ein Unterschied in der Spielstärke ab: Patrick spielte an Brett 4 gegen Linus Koll (DWZ>1900) und kam nicht gut aus der Eröffnung. Sein Gegner ließ wenig Gegenspiel zu und konnte nach etwas mehr als zwei Stunden die Führung für die Gäste sicherstellen. Kurz darauf verlor auch Jens an Brett 1, der von seinem Gegner in der Eröffnung überrascht wurde. Er schaffte es zwar, eine aus Computersicht in etwa ausgeglichene Stellung zu erreichen. Jedoch war die Stellung weiterhin unangenehm zu spielen und so beging er einen taktischen Fehler, der ihn die Partie kostete. Aber es lief nicht an allen Brettern schlecht: Noah kam gut aus der Eröffnung und hatte durchweg eine solide Stellung. So gewann er im Mittelspiel eine Qualität gegen seinen Gegner mit über 2100 DWZ und konnte kurz darauf auf 1-2 verkürzen.

--- a/content/blog/article/20240730.unterlaender-schachtage-2024.md
+++ b/content/blog/article/20240730.unterlaender-schachtage-2024.md
@@ -4,7 +4,11 @@ authors:
   - dimitrios-triantafillidis
 category: Verein
 date: 2024-07-30
-description: 'Rekordteilnehmer bei den 5. Unterländer Schachtagen: Siege für Pijpers, Link und Löffler.'
+description: "Rekordteilnehmer bei den 5. Unterländer Schachtagen: Siege für Pijpers, Link und Löffler."
+sitemap:
+  loc: /blog/article/unterlaender-schachtage-2024
+status: published
+toc: true
 tournament: internationale-unterlaender-schachtage
 ---
 

--- a/content/blog/article/20240909.biberacher-schachsommer-2024.md
+++ b/content/blog/article/20240909.biberacher-schachsommer-2024.md
@@ -4,7 +4,11 @@ authors:
   - hubert-warsitz
 category: Verein
 date: 2024-09-09
-description: "Rekordsieger Noah Geltz dominiert den Biberacher Schach-Sommer 2024 mit 96,7\_% Gewinnquote. Erfolgreiche Teilnahme von 38 Spielern aus acht Vereinen."
+description: Rekordsieger Noah Geltz dominiert den Biberacher Schach-Sommer 2024 mit 96,7 % Gewinnquote. Erfolgreiche Teilnahme von 38 Spielern aus acht Vereinen.
+sitemap:
+  loc: /blog/article/biberacher-schachsommer-2024
+status: published
+toc: true
 tournament: biberacher-schach-sommer
 ---
 
@@ -28,12 +32,12 @@ Die Schachfreunde Biberach bedanken sich für die fairen Turnierteilnahmen und f
 
 ## Die Ergebnisse im Überblick
 
-[1. Spieltag (Schnellschach)](/assets/blog/20240909.biberacher-schachsommer-2024/1-spieltag-schnellschach.pdf){external="" target="_blank"} :br
-[2. Spieltag (Blitzschach)](/assets/blog/20240909.biberacher-schachsommer-2024/2-spieltag-blitzschach.pdf){external="" target="_blank"} :br
-[3. Spieltag (Schnellschach)](/assets/blog/20240909.biberacher-schachsommer-2024/3-spieltag-schnellschach.pdf){external="" target="_blank"} :br
-[4. Spieltag (Blitzschach)](/assets/blog/20240909.biberacher-schachsommer-2024/4-spieltag-blitzschach.pdf){external="" target="_blank"} :br
-[5. Spieltag (Schnellschach)](/assets/blog/20240909.biberacher-schachsommer-2024/5-spieltag-schnellschach.pdf){external="" target="_blank"} :br
-[6. Spieltag (Blitzschach)](/assets/blog/20240909.biberacher-schachsommer-2024/6-spieltag-blitzschach.pdf){external="" target="_blank"}
+- [1. Spieltag (Schnellschach)](/assets/blog/20240909.biberacher-schachsommer-2024/1-spieltag-schnellschach.pdf){external="" target="_blank"}
+- [2. Spieltag (Blitzschach)](/assets/blog/20240909.biberacher-schachsommer-2024/2-spieltag-blitzschach.pdf){external="" target="_blank"}
+- [3. Spieltag (Schnellschach)](/assets/blog/20240909.biberacher-schachsommer-2024/3-spieltag-schnellschach.pdf){external="" target="_blank"}
+- [4. Spieltag (Blitzschach)](/assets/blog/20240909.biberacher-schachsommer-2024/4-spieltag-blitzschach.pdf){external="" target="_blank"}
+- [5. Spieltag (Schnellschach)](/assets/blog/20240909.biberacher-schachsommer-2024/5-spieltag-schnellschach.pdf){external="" target="_blank"}
+- [6. Spieltag (Blitzschach)](/assets/blog/20240909.biberacher-schachsommer-2024/6-spieltag-blitzschach.pdf){external="" target="_blank"}
 
 [Gesamtstand nach dem 6. Spieltag](/assets/blog/20240909.biberacher-schachsommer-2024/gesamtstand.pdf){external="" target="_blank"}
 

--- a/content/blog/article/20240925.sc-tettnang-1-sf-hn-biberach-1.md
+++ b/content/blog/article/20240925.sc-tettnang-1-sf-hn-biberach-1.md
@@ -5,6 +5,10 @@ authors:
 category: Mannschaft
 date: 2024-09-25
 description: HN-Biberach siegt bei Oberliga-Premiere gegen Tettnang mit 5,5:2,5. Mannschaftsgeist und starke Einzelleistungen sichern den Erfolg.
+sitemap:
+  loc: /blog/article/sc-tettnang-1-sf-hn-biberach-1
+status: published
+toc: true
 ---
 
 Die Oberliga ist für HN-Biberach Neuland und das gilt auch für den Auftaktgegner Tettnang am Bodensee. HN-Biberach 1 zelebrierte die Premiere eindrucksvoll: Für Samstag wurde ein Mannschaftstraining in Heilbronn einberufen und nach fünf Stunden fuhr die Mannschaft nach Marktbeuren ins Ristorante, um Mannschaftsgeschlossenheit zu leben. Die Truppe übernachtete in einer Ferienwohnung und sie stimmte sich auf die Gegner ein.

--- a/content/blog/article/20250324.14-biber-jugend-cup.md
+++ b/content/blog/article/20250324.14-biber-jugend-cup.md
@@ -8,6 +8,7 @@ description: Rekordbeteiligung und packende Duelle – 213 junge Talente beeindr
 sitemap:
   loc: /blog/article/14-biber-jugend-cup
 status: published
+toc: true
 tournament: biber-jugend-cup
 ---
 

--- a/content/blog/article/20250624.bericht-ko-pokal-wuerttemberg-runde-1.md
+++ b/content/blog/article/20250624.bericht-ko-pokal-wuerttemberg-runde-1.md
@@ -1,10 +1,14 @@
 ---
-title: 'KO-Pokal Württemberg: SF HN-Biberach vs. Heilbronner SV'
+title: "KO-Pokal Württemberg: SF HN-Biberach vs. Heilbronner SV"
 authors:
   - jens-hoffmann
 category: Mannschaft
 date: 2025-05-25
 description: Knappe 1:3-Niederlage gegen den Favoriten – SF HN-Biberach zeigt großen Kampfgeist
+sitemap:
+  loc: /blog/article/bericht-ko-pokal-wuerttemberg-runde-1
+status: published
+toc: true
 ---
 
 Die SF HN-Biberach starteten direkt mit einer anspruchsvollen Auswärtsaufgabe in die württembergische Ebene des KO-Pokals: Es ging gegen den Heilbronner Schachverein – ein Duell mit regionalem Reiz und schachlich vielversprechenden Paarungen. Trotz couragierter Leistungen reichte es am Ende nicht für die Überraschung.

--- a/content/blog/article/20251012.sf-hn-biberach-3-sk-schwaebisch-hall-3.md
+++ b/content/blog/article/20251012.sf-hn-biberach-3-sk-schwaebisch-hall-3.md
@@ -5,6 +5,10 @@ authors:
 category: Mannschaft
 date: 2025-10-12
 description: 2. Spieltag zu Hause in der Kreisklasse Unterland Nord
+sitemap:
+  loc: /blog/article/sf-hn-biberach-3-sk-schwaebisch-hall-3
+status: published
+toc: true
 ---
 
 Nach dem klaren Sieg am ersten Spieltag in Öhringen feierten wir die Heimspielpremiere dieser Saison zu Hause gegen die SK Schwäbisch Hall 3. Die Mannschaft musste krankheitsbedingt auf einigen Positionen umgestellt werden, sodass das Team an 3 Brettern anders aussah, also in der Woche davor. Für unsere 2 Jugendspieler Jan Hirth (Brett 7) und David Ilnizki (Brett 8) war es die Premiere in der 3.Mannschaft. An Brett 6 feierte Andreas Hellriegel sein Mannschaftsdebüt in dieser Saison.

--- a/content/blog/article/20251102.sf-schwaigern-4-sf-hn-biberach-4.md
+++ b/content/blog/article/20251102.sf-schwaigern-4-sf-hn-biberach-4.md
@@ -5,7 +5,10 @@ authors:
 category: Mannschaft
 date: 2025-11-02
 description: Schwarzer Sonntag für die Vierte der Schachfreunde Heilbronn-Biberach
+sitemap:
+  loc: /blog/article/sf-schwaigern-4-sf-hn-biberach-4
 status: published
+toc: true
 ---
 
 In der dritten Runde der B-Klasse traf die vierte Mannschaft der Schachfreunde Heilbronn-Biberach 1978 e.V. auf die vierte Mannschaft der Schachfreunde Schwaigern. Leider mussten die Biberacher auf ihre beiden Spitzenbretter verzichten, die verhindert waren. Dafür kamen Nachwuchstalent Jan Hirth an Brett 4 und Vereinsnestor Detlef Offergeld an Brett 5 zum Einsatz. Für Detlef war es ein besonderer Moment, da er sich nach einer schweren Erkrankung noch in der Aufbauphase befindet.

--- a/content/blog/article/20251207.sk-wernau-1-sf-hn-biberach-1.md
+++ b/content/blog/article/20251207.sk-wernau-1-sf-hn-biberach-1.md
@@ -5,6 +5,10 @@ authors:
 category: Mannschaft
 date: 2025-12-07
 description: Schachfreunde Heilbronn-Biberach unterliegen knapp in Wernau
+sitemap:
+  loc: /blog/article/sk-wernau-1-sf-hn-biberach-1
+status: published
+toc: true
 ---
 
 In der 4. Runde der Oberliga Württemberg mussten die Schachfreunde Heilbronn-Biberach ihre erste Saisonniederlage hinnehmen. Trotz Tabellenführung und guter Ausgangslage reiste das Team nicht in Bestbesetzung zum Auswärtsspiel nach Wernau – und unterlag am Ende knapp mit 3,5:4,5.

--- a/content/blog/article/nachruf-detlef-offergeld.md
+++ b/content/blog/article/nachruf-detlef-offergeld.md
@@ -1,8 +1,10 @@
 ---
 title: "Nachruf: Detlef Offergeld"
-description: In tiefer Trauer nehmen wir Abschied von unserem Gründungsmitglied
 category: Verein
 date: 2026-04-20
+description: In tiefer Trauer nehmen wir Abschied von unserem Gründungsmitglied
+sitemap:
+  loc: /blog/article/nachruf-detlef-offergeld
 status: published
 toc: true
 ---

--- a/content/index.yaml
+++ b/content/index.yaml
@@ -37,6 +37,6 @@ hero:
     - label: Lerne uns kennen
       to: /#training
       icon: i-ph-arrow-bend-right-down-duotone
-      color: gray
+      color: neutral
 sitemap:
   loc: /

--- a/content/mannschaften/1.mannschaft-1.md
+++ b/content/mannschaften/1.mannschaft-1.md
@@ -1,11 +1,16 @@
 ---
 title: 1. Mannschaft
 description: Unser Top-Team durfte in der Saison 2024/25 zum ersten Mal in der Vereinsgeschichte in der Oberliga Württemberg antreten und hat die Klasse souverän gehalten. Der DWZ-Schnitt an den ersten acht Brettern liegt jenseits der 2000, was auch dem großen Anteil eigener Nachwuchsspieler zu verdanken ist.
+league:
+  provider: nuliga
+  season: 2025/26
+  groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=W%C3%9C+25%2F26&group=4211
+  teamName: SF HN-Biberach 1
 header:
   ui: {}
   links: []
 links:
-  - label: Tablelle und Spielplan
+  - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=W%C3%9C+25%2F26&group=4211
     target: _blank
     color: neutral
@@ -16,5 +21,5 @@ sitemap:
   videos: []
   images: []
 status: published
-toc: true
+toc: false
 ---

--- a/content/mannschaften/1.mannschaft-1.md
+++ b/content/mannschaften/1.mannschaft-1.md
@@ -1,14 +1,14 @@
 ---
 title: 1. Mannschaft
 description: Unser Top-Team durfte in der Saison 2024/25 zum ersten Mal in der Vereinsgeschichte in der Oberliga Württemberg antreten und hat die Klasse souverän gehalten. Der DWZ-Schnitt an den ersten acht Brettern liegt jenseits der 2000, was auch dem großen Anteil eigener Nachwuchsspieler zu verdanken ist.
+header:
+  ui: {}
+  links: []
 league:
   provider: nuliga
   season: 2025/26
   groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=W%C3%9C+25%2F26&group=4211
   teamName: SF HN-Biberach 1
-header:
-  ui: {}
-  links: []
 links:
   - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=W%C3%9C+25%2F26&group=4211

--- a/content/mannschaften/2.mannschaft-2.md
+++ b/content/mannschaften/2.mannschaft-2.md
@@ -1,14 +1,14 @@
 ---
 title: 2. Mannschaft
 description: Unsere zweite Mannschaft spielt in der Bezirksliga Unterland Nord und zeichnet sich durch eine sehr homogene Spielstärke aus. Gleichzeitig haben wir hier eine bunte Mischung aus jung und alt.
+header:
+  ui: {}
+  links: []
 league:
   provider: nuliga
   season: 2025/26
   groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4170
   teamName: SF HN-Biberach 2
-header:
-  ui: {}
-  links: []
 links:
   - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4170

--- a/content/mannschaften/2.mannschaft-2.md
+++ b/content/mannschaften/2.mannschaft-2.md
@@ -1,11 +1,16 @@
 ---
 title: 2. Mannschaft
 description: Unsere zweite Mannschaft spielt in der Bezirksliga Unterland Nord und zeichnet sich durch eine sehr homogene Spielstärke aus. Gleichzeitig haben wir hier eine bunte Mischung aus jung und alt.
+league:
+  provider: nuliga
+  season: 2025/26
+  groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4170
+  teamName: SF HN-Biberach 2
 header:
   ui: {}
   links: []
 links:
-  - label: Tablelle und Spielplan
+  - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4170
     target: _blank
     color: neutral
@@ -16,5 +21,5 @@ sitemap:
   videos: []
   images: []
 status: published
-toc: true
+toc: false
 ---

--- a/content/mannschaften/3.mannschaft-3.md
+++ b/content/mannschaften/3.mannschaft-3.md
@@ -1,8 +1,13 @@
 ---
 title: 3. Mannschaft
 description: SF HN-Biberach 3 geht in der Kreisliga Nord an die Bretter und hat sich dort in der vergangenen Saison einen soliden Mittelfeldplatz erkämpft.
+league:
+  provider: nuliga
+  season: 2025/26
+  groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4166
+  teamName: SF HN-Biberach 3
 links:
-  - label: Tablelle und Spielplan
+  - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4166
     target: _blank
     color: neutral
@@ -11,5 +16,5 @@ links:
 sitemap:
   loc: /mannschaften/mannschaft-3
 status: published
-toc: true
+toc: false
 ---

--- a/content/mannschaften/4.mannschaft-4.md
+++ b/content/mannschaften/4.mannschaft-4.md
@@ -1,8 +1,13 @@
 ---
 title: 4. Mannschaft
 description: Seit Beginn der Saison 2025/26 stellen wir wieder eine vierte Mannschaft, die in der B-Klasse startet und in der vor allem einige Neumitglieder auf Punktejagd gehen.
+league:
+  provider: nuliga
+  season: 2025/26
+  groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4167
+  teamName: SF HN-Biberach 4
 links:
-  - label: Tablelle und Spielplan
+  - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+25%2F26&group=4167
     target: _blank
     color: neutral
@@ -11,5 +16,5 @@ links:
 sitemap:
   loc: /mannschaften/mannschaft-4
 status: published
-toc: true
+toc: false
 ---

--- a/content/mannschaften/5.mannschaft-jugend-1.md
+++ b/content/mannschaften/5.mannschaft-jugend-1.md
@@ -1,8 +1,13 @@
 ---
 title: 1. Jugendmannschaft
 description: Nach zahlreichen altersbedingten Abgängen konnten wir die Verbandsjugendliga leider nicht halten. Frischen Wind bringt unser junger Nachwuchs, der in 2025/26 den Wiederaufstieg ins Visier nehmen wird!
+league:
+  provider: nuliga
+  season: 2025/26
+  groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+Jugend+25%2F26&group=4236
+  teamName: SF HN-Biberach 1
 links:
-  - label: Tablelle und Spielplan
+  - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+Jugend+25%2F26&group=4236
     target: _blank
     color: neutral
@@ -11,5 +16,5 @@ links:
 sitemap:
   loc: /mannschaften/mannschaft-jugend-1
 status: published
-toc: true
+toc: false
 ---

--- a/content/mannschaften/6.mannschaft-jugend-2.md
+++ b/content/mannschaften/6.mannschaft-jugend-2.md
@@ -1,8 +1,13 @@
 ---
 title: 2. Jugendmannschaft
 description: Hier können unsere jüngeren Einsteiger ihre erste Spielpraxis im Ligensystem sammeln und sich auf die späteren Herausforderungen in unseren Erwachsenenmannschaften vorbereiten.
+league:
+  provider: nuliga
+  season: 2025/26
+  groupUrl: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+Jugend+25%2F26&group=4236
+  teamName: SF HN-Biberach 2
 links:
-  - label: Tablelle und Spielplan
+  - label: Daten bei nuLiga öffnen
     to: https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?championship=Unterland+Jugend+25%2F26&group=4236
     target: _blank
     color: neutral
@@ -11,5 +16,5 @@ links:
 sitemap:
   loc: /mannschaften/mannschaft-jugend-2
 status: published
-toc: true
+toc: false
 ---

--- a/content/pages/blog.yaml
+++ b/content/pages/blog.yaml
@@ -9,6 +9,3 @@ sitemap:
   videos: []
   images: []
 toc: true
-hero:
-  links: []
-status: published

--- a/content/pages/datenschutz.md
+++ b/content/pages/datenschutz.md
@@ -1,10 +1,10 @@
 ---
 title: Datenschutzerklärung
 description: Informationen über die Datenerhebung, -verarbeitung und -schutzrichtlinien der Webseite.
-layout:
-  toc: true
+layout: content
 sitemap:
   loc: /datenschutz
+toc: true
 ---
 
 ## 1. Datenschutz auf einen Blick

--- a/content/pages/impressum.md
+++ b/content/pages/impressum.md
@@ -1,8 +1,8 @@
 ---
 title: Impressum
 description: Kontaktdaten und rechtliche Informationen des Webseitenbetreibers.
-layout:
-  toc: true
+layout: content
+toc: true
 sitemap:
   loc: /impressum
 ---

--- a/content/pages/mannschaften.yaml
+++ b/content/pages/mannschaften.yaml
@@ -9,6 +9,3 @@ sitemap:
   videos: []
   images: []
 toc: true
-hero:
-  links:
-    - {}

--- a/content/pages/turniere.yaml
+++ b/content/pages/turniere.yaml
@@ -9,5 +9,3 @@ sitemap:
   videos: []
   images: []
 toc: true
-hero:
-  links: []

--- a/content/users/dimitrios-triantafillidis.yaml
+++ b/content/users/dimitrios-triantafillidis.yaml
@@ -1,5 +1,5 @@
-username: dimitrios-triantafillidis
-name: Dimitrios Triantafillidis
-to: https://www.instagram.com/dimitraculix
 avatar:
   src: /assets/users/dimitrios-triantafillidis.jpg
+name: Dimitrios Triantafillidis
+to: https://www.instagram.com/dimitraculix
+username: dimitrios-triantafillidis

--- a/content/users/hubert-warsitz.yaml
+++ b/content/users/hubert-warsitz.yaml
@@ -1,3 +1,2 @@
-username: hubert-warsitz
 name: Hubert Warsitz
-socials: []
+username: hubert-warsitz

--- a/content/users/jens-hoffmann.yaml
+++ b/content/users/jens-hoffmann.yaml
@@ -1,4 +1,4 @@
-username: jens-hoffmann
-name: Jens Hoffmann
 avatar:
   src: /assets/users/jens-hoffmann.jpg
+name: Jens Hoffmann
+username: jens-hoffmann

--- a/content/users/philipp-mueller.yaml
+++ b/content/users/philipp-mueller.yaml
@@ -1,5 +1,5 @@
-username: philipp-mueller
-name: Philipp Müller
-to: https://www.instagram.com/muelphil
 avatar:
   src: /assets/users/philipp-mueller.jpg
+name: Philipp Müller
+to: https://www.instagram.com/muelphil
+username: philipp-mueller

--- a/content/users/robin-gerold.yaml
+++ b/content/users/robin-gerold.yaml
@@ -1,2 +1,2 @@
-username: robin-gerold
 name: Robin Gerold
+username: robin-gerold

--- a/content/users/stephanie-gerold.yaml
+++ b/content/users/stephanie-gerold.yaml
@@ -1,2 +1,2 @@
-username: stephanie-gerold
 name: Stephanie Gerold
+username: stephanie-gerold

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -65,7 +65,6 @@ export default defineNuxtConfig({
       ignore: [route => route.startsWith('/mannschaften/') && !route.endsWith('/_payload.json')],
       routes: ['/', '/impressum', '/datenschutz', '/sitemap.xml', '/api/navigation.json', '/api/search.json'],
     },
-    preset: 'cloudflare_module',
     cloudflare: {
       deployConfig: true,
       nodeCompat: true,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -37,7 +37,6 @@ export default defineNuxtConfig({
     '/': { prerender: true },
     '/blog/rss.xml': { prerender: true },
     '/mannschaften': { prerender: true },
-    '/mannschaften/**': { prerender: false },
   },
 
   experimental: {
@@ -63,6 +62,7 @@ export default defineNuxtConfig({
       crawlLinks: true,
       autoSubfolderIndex: false,
       failOnError: true,
+      ignore: [route => route.startsWith('/mannschaften/') && !route.endsWith('/_payload.json')],
       routes: ['/', '/impressum', '/datenschutz', '/sitemap.xml', '/api/navigation.json', '/api/search.json'],
     },
     preset: 'cloudflare_module',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,6 +36,8 @@ export default defineNuxtConfig({
   routeRules: {
     '/': { prerender: true },
     '/blog/rss.xml': { prerender: true },
+    '/mannschaften': { prerender: true },
+    '/mannschaften/**': { prerender: false },
   },
 
   experimental: {
@@ -45,6 +47,18 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-07-09',
 
   nitro: {
+    storage: {
+      cache: {
+        driver: 'cloudflare-kv-binding',
+        binding: 'NULIGA_CACHE',
+      },
+    },
+    devStorage: {
+      cache: {
+        driver: 'fs',
+        base: './.data/nuliga-cache',
+      },
+    },
     prerender: {
       crawlLinks: true,
       autoSubfolderIndex: false,
@@ -55,6 +69,10 @@ export default defineNuxtConfig({
     cloudflare: {
       deployConfig: true,
       nodeCompat: true,
+      wrangler: {
+        d1_databases: [{ binding: 'DB' }],
+        kv_namespaces: [{ binding: 'NULIGA_CACHE' }],
+      },
     },
     virtual: {
       sharp: 'export default function sharp() { return {} }',

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "serve": "wrangler dev --config .output/server/wrangler.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "vitest run",
     "typecheck": "nuxt typecheck",
     "generate-pwa-assets": "pwa-assets-generator"
   },
@@ -32,6 +33,7 @@
     "@vueuse/core": "^14.3.0",
     "@vueuse/nuxt": "^14.3.0",
     "better-sqlite3": "^12.11.1",
+    "cheerio": "^1.2.0",
     "feed": "^6.0.0",
     "nuxt-studio": "^1.7.0"
   },
@@ -46,8 +48,9 @@
     "nuxt": "^4.4.8",
     "typescript": "^6.0.3",
     "unhead": "3.1.7",
+    "vitest": "^4.1.10",
     "vue-tsc": "^3.3.7",
-    "wrangler": "^4.107.1",
+    "wrangler": "^4.110.0",
     "zod": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "private": true,
   "packageManager": "pnpm@11.11.0",
   "scripts": {
-    "dev": "nuxt dev",
-    "build": "cross-env NODE_OPTIONS='--max-old-space-size=4096' nuxt build",
-    "generate": "nuxt generate && node scripts/validate-generated-output.mjs",
+    "predev": "node scripts/prepare-nuxt-dev-cache.mjs",
+    "dev": "cross-env NUXT_LOCK=1 nuxt dev",
+    "build": "cross-env NUXT_LOCK=1 NODE_OPTIONS='--max-old-space-size=4096' nuxt build",
+    "generate": "cross-env NUXT_LOCK=1 nuxt generate && node scripts/validate-generated-output.mjs",
     "preview": "nuxt preview",
     "serve": "wrangler dev --config .output/server/wrangler.json",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,18 @@
   "scripts": {
     "predev": "node scripts/prepare-nuxt-dev-cache.mjs",
     "dev": "cross-env NUXT_LOCK=1 nuxt dev",
-    "build": "cross-env NUXT_LOCK=1 NODE_OPTIONS='--max-old-space-size=4096' nuxt build",
+    "build": "cross-env NITRO_PRESET=cloudflare_module NUXT_LOCK=1 NODE_OPTIONS='--max-old-space-size=4096' nuxt build",
     "generate": "cross-env NUXT_LOCK=1 nuxt generate && node scripts/validate-generated-output.mjs",
     "preview": "nuxt preview",
     "serve": "wrangler dev --config .output/server/wrangler.json",
-    "lint": "eslint .",
+    "lint": "eslint . && pnpm contentcheck",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "typecheck": "nuxt typecheck",
-    "generate-pwa-assets": "pwa-assets-generator"
+    "generate-pwa-assets": "pwa-assets-generator",
+    "prebuild": "pnpm lint",
+    "pregenerate": "pnpm lint",
+    "contentcheck": "nuxt prepare && node scripts/validate-content.mjs"
   },
   "dependencies": {
     "@happydesigns/nuxt-variants": "^0.0.6",
@@ -52,6 +55,7 @@
     "vitest": "^4.1.10",
     "vue-tsc": "^3.3.7",
     "wrangler": "^4.110.0",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   }
 }

--- a/patches/nuxt-studio@1.7.0.patch
+++ b/patches/nuxt-studio@1.7.0.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/module/runtime/host.dev.js b/dist/module/runtime/host.dev.js
+index 90b762120def07fb64351041d9097ecfe405530c..c9c9e7e9a99d93a0676412b25f07c4b9e0048d43 100644
+--- a/dist/module/runtime/host.dev.js
++++ b/dist/module/runtime/host.dev.js
+@@ -25,6 +25,13 @@ export function useStudioHost(user, repository) {
+     }
+     const id = generateIdFromFsPath(fsPath, collectionInfo);
+     const document = applyCollectionSchema(id, collectionInfo, upsertedDocument);
++    const currentDocument = await host.document.db.get(fsPath);
++    if (currentDocument) {
++      const normalizedCurrentDocument = applyCollectionSchema(id, collectionInfo, currentDocument);
++      if (host.document.utils.areEqual(normalizedCurrentDocument, document)) {
++        return;
++      }
++    }
+     const sanitizedDocument = sanitizeDocumentTree(document, collectionInfo);
+     const content = await host.document.generate.contentFromDocument(sanitizedDocument);
+     await $fetch("/__nuxt_studio/dev/content/" + fsPath, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
+      cheerio:
+        specifier: ^1.2.0
+        version: 1.2.0
       feed:
         specifier: ^6.0.0
         version: 6.0.0
@@ -70,7 +73,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^9.1.0
-        version: 9.1.0(@typescript-eslint/rule-tester@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3))(@typescript-eslint/utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 9.1.0(@typescript-eslint/rule-tester@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3))(@typescript-eslint/utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)))
       '@nuxt/eslint':
         specifier: ^1.16.0
         version: 1.16.0(@typescript-eslint/utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(eslint@10.6.0(jiti@2.7.0))(magicast@0.5.3)(oxc-parser@0.137.0)(rollup@4.62.2)(typescript@6.0.3)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
@@ -98,12 +101,15 @@ importers:
       unhead:
         specifier: 3.1.7
         version: 3.1.7(esbuild@0.28.1)(rollup@4.62.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.7
         version: 3.3.7(typescript@6.0.3)
       wrangler:
-        specifier: ^4.107.1
-        version: 4.107.1
+        specifier: ^4.110.0
+        version: 4.110.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -799,32 +805,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260702.1':
-    resolution: {integrity: sha512-D5+vnLlvfkanyFpgyE+K8JtFGr9qcKEaMIv6iGus1bz7gegr8zWF5HLwJ5LbebdyeVWl+IzpT7m5LJQsHOcJ4Q==}
+  '@cloudflare/workerd-darwin-64@1.20260708.1':
+    resolution: {integrity: sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260702.1':
-    resolution: {integrity: sha512-CkJNyrOzuIWil87qztB5cE6b9z+0c2Ewc8yrkSfahsdATxmjD+mrLIpJ0IkW9bqCOS1JE1kDEtfx9D4/ZpKW6w==}
+  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
+    resolution: {integrity: sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260702.1':
-    resolution: {integrity: sha512-FhJl4cZQNqlG5v7LQRvzTes2q8hHylf60ecQ4Es0YvJ0hvRO30FOU2f4WSEIkZahs1HNCYxf2EL9GJQ/vIx1Ig==}
+  '@cloudflare/workerd-linux-64@1.20260708.1':
+    resolution: {integrity: sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260702.1':
-    resolution: {integrity: sha512-EuXdOgwE08sbfVJsI9JHXUxf2Xlqy51P1nQt+wIDN5kcLzfkW0hbKw/GVLupLBhivGdFRfSBM9SUn/+3uMneuQ==}
+  '@cloudflare/workerd-linux-arm64@1.20260708.1':
+    resolution: {integrity: sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260702.1':
-    resolution: {integrity: sha512-84X5kRiUo9vUEWAaj/vOamPqQJK21KOUWuQ48MccFbzG+LPCZP0EGb36dQZd1OmKoZ1dYHPWB0zBAoI7tygc2w==}
+  '@cloudflare/workerd-windows-64@1.20260708.1':
+    resolution: {integrity: sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -3702,8 +3708,14 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -4043,6 +4055,35 @@ packages:
       vitest:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
@@ -4292,6 +4333,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -4502,6 +4547,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
@@ -4520,6 +4569,13 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -4992,6 +5048,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -5354,6 +5413,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -5758,6 +5821,9 @@ packages:
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -5779,6 +5845,10 @@ packages:
 
   ico-endec@0.1.6:
     resolution: {integrity: sha512-ZdLU38ZoED3g1j3iEyzcQj+wAkY2xfWNkymszfJPoxucIUhK7NayQ+/C4Kv0nDFMIsbtbEHldv3V8PU494/ueQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -6506,8 +6576,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@4.20260702.0:
-    resolution: {integrity: sha512-OqX/HwWWu0JqLQ7aCQU0int9fmpMzRjVWDo0T1WJDTssYc7KlaMM3G8N8HUEunkBMflmgI8TiAqmZTISqcVmEw==}
+  miniflare@4.20260708.1:
+    resolution: {integrity: sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -6948,6 +7018,12 @@ packages:
   parse-url@9.2.0:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -7520,6 +7596,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -7634,6 +7713,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -7733,6 +7815,9 @@ packages:
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -7919,6 +8004,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -7930,6 +8018,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -8449,6 +8541,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -8533,6 +8666,15 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -8567,6 +8709,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -8628,17 +8775,17 @@ packages:
   workbox-window@7.4.1:
     resolution: {integrity: sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==}
 
-  workerd@1.20260702.1:
-    resolution: {integrity: sha512-rkIDTWQ7yhC0BjWBDuKj/q9JsOBzrGt/KdOeun+c4YlN47W4l0pa5aCyE1X6A47/ju3h6BEFhrO1CibZ5EgSpA==}
+  workerd@1.20260708.1:
+    resolution: {integrity: sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.107.1:
-    resolution: {integrity: sha512-HMulqgQtNvY9UKXu6nTRTqv5GhtN1RhZeG9cPX+kS8R6s7o7ct6rueoXiNe4MX8+88B7p4lq3RvSPzB205fexg==}
+  wrangler@4.110.0:
+    resolution: {integrity: sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260702.1
+      '@cloudflare/workers-types': ^5.20260708.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -8799,7 +8946,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@antfu/eslint-config@9.1.0(@typescript-eslint/rule-tester@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3))(@typescript-eslint/utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@antfu/eslint-config@9.1.0(@typescript-eslint/rule-tester@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3))(@typescript-eslint/utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.7.0
@@ -8809,7 +8956,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.6.0(jiti@2.7.0))
       '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/parser': 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      '@vitest/eslint-plugin': 1.6.22(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@vitest/eslint-plugin': 1.6.22(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)))
       ansis: 4.3.1
       cac: 7.0.0
       eslint: 10.6.0(jiti@2.7.0)
@@ -9599,25 +9746,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260702.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260702.1
+      workerd: 1.20260708.1
 
-  '@cloudflare/workerd-darwin-64@1.20260702.1':
+  '@cloudflare/workerd-darwin-64@1.20260708.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260702.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260708.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260702.1':
+  '@cloudflare/workerd-linux-64@1.20260708.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260702.1':
+  '@cloudflare/workerd-linux-arm64@1.20260708.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260702.1':
+  '@cloudflare/workerd-windows-64@1.20260708.1':
     optional: true
 
   '@colordx/core@5.5.0': {}
@@ -12631,9 +12778,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -12987,7 +13141,7 @@ snapshots:
       vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@6.0.3)
 
-  '@vitest/eslint-plugin@1.6.22(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@vitest/eslint-plugin@1.6.22(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/utils': 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
@@ -12995,8 +13149,50 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       typescript: 6.0.3
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -13294,6 +13490,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.7
@@ -13503,6 +13701,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
@@ -13514,6 +13714,29 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.28.0
+      whatwg-mimetype: 4.0.0
 
   chokidar@5.0.0:
     dependencies:
@@ -13944,6 +14167,11 @@ snapshots:
   empathic@2.0.1: {}
 
   encodeurl@2.0.0: {}
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
 
   end-of-stream@1.4.5:
     dependencies:
@@ -14497,6 +14725,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.4.0: {}
+
   exsolve@1.1.0: {}
 
   extend@3.0.2: {}
@@ -15015,6 +15245,13 @@ snapshots:
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -15037,6 +15274,10 @@ snapshots:
   human-signals@5.0.0: {}
 
   ico-endec@0.1.6: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb@7.1.1: {}
 
@@ -15985,12 +16226,12 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  miniflare@4.20260702.0:
+  miniflare@4.20260708.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.28.0
-      workerd: 1.20260702.1
+      workerd: 1.20260708.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -17250,6 +17491,15 @@ snapshots:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -17950,6 +18200,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sax@1.6.0: {}
 
   scslre@0.3.0:
@@ -18175,6 +18427,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -18273,6 +18527,8 @@ snapshots:
   srvx@0.11.21: {}
 
   stable-hash-x@0.2.0: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -18508,6 +18764,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.15: {}
 
   tinyexec@1.2.4: {}
@@ -18516,6 +18774,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -19094,6 +19354,34 @@ snapshots:
       terser: 5.49.0
       yaml: 2.9.0
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.3.1:
@@ -19187,6 +19475,12 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -19248,6 +19542,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
@@ -19371,24 +19670,24 @@ snapshots:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.1
 
-  workerd@1.20260702.1:
+  workerd@1.20260708.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260702.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260702.1
-      '@cloudflare/workerd-linux-64': 1.20260702.1
-      '@cloudflare/workerd-linux-arm64': 1.20260702.1
-      '@cloudflare/workerd-windows-64': 1.20260702.1
+      '@cloudflare/workerd-darwin-64': 1.20260708.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260708.1
+      '@cloudflare/workerd-linux-64': 1.20260708.1
+      '@cloudflare/workerd-linux-arm64': 1.20260708.1
+      '@cloudflare/workerd-windows-64': 1.20260708.1
 
-  wrangler@4.107.1:
+  wrangler@4.110.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260702.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260702.0
+      miniflare: 4.20260708.1
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260702.1
+      workerd: 1.20260708.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   workbox-build@7.4.0>rollup: 2.79.2
   workbox-build: 7.4.0
 
+patchedDependencies:
+  nuxt-studio@1.7.0: 7efce88971ab16ab3219f8392e8d093d6586b0d648d65f320bb97fd33a95c56f
+
 importers:
 
   .:
@@ -69,7 +72,7 @@ importers:
         version: 6.0.0
       nuxt-studio:
         specifier: ^1.7.0
-        version: 1.7.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@6.0.3))
+        version: 1.7.0(patch_hash=7efce88971ab16ab3219f8392e8d093d6586b0d648d65f320bb97fd33a95c56f)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@6.0.3))
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^9.1.0
@@ -110,6 +113,9 @@ importers:
       wrangler:
         specifier: ^4.110.0
         version: 4.110.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -10161,7 +10167,7 @@ snapshots:
       '@nuxt/ui': 4.9.0(46bfd1636ede9bf5ce73c754e847ac60)
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@6.0.3))
       better-sqlite3: 12.11.1
-      nuxt-studio: 1.7.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@6.0.3))
+      nuxt-studio: 1.7.0(patch_hash=7efce88971ab16ab3219f8392e8d093d6586b0d648d65f320bb97fd33a95c56f)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@6.0.3))
       pathe: 2.0.3
       zod: 4.4.3
     transitivePeerDependencies:
@@ -16871,7 +16877,7 @@ snapshots:
       - vue
       - zod
 
-  nuxt-studio@1.7.0(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@6.0.3)):
+  nuxt-studio@1.7.0(patch_hash=7efce88971ab16ab3219f8392e8d093d6586b0d648d65f320bb97fd33a95c56f)(db0@0.3.4(better-sqlite3@12.11.1))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.21)(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@ai-sdk/gateway': 3.0.145(zod@4.4.3)
       '@ai-sdk/vue': 3.0.221(vue@3.5.39(typescript@6.0.3))(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - "@happydesigns/ui@0.15.0 || 0.15.1"
+
+patchedDependencies:
+  nuxt-studio@1.7.0: patches/nuxt-studio@1.7.0.patch

--- a/scripts/prepare-nuxt-dev-cache.mjs
+++ b/scripts/prepare-nuxt-dev-cache.mjs
@@ -1,0 +1,23 @@
+import { lstat, mkdir, rm } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const payloadCachePath = resolve('.nuxt/cache/nuxt/payload')
+
+try {
+  const cacheEntry = await lstat(payloadCachePath)
+
+  if (cacheEntry.isFile()) {
+    await rm(payloadCachePath)
+    console.info('Migrated legacy Nuxt payload cache.')
+  }
+  else if (!cacheEntry.isDirectory()) {
+    throw new Error(`Unexpected Nuxt payload cache entry at ${payloadCachePath}`)
+  }
+}
+catch (error) {
+  if (error?.code !== 'ENOENT') {
+    throw error
+  }
+}
+
+await mkdir(payloadCachePath, { recursive: true })

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -1,0 +1,141 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, extname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+
+const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const contentDir = resolve(projectDir, 'content')
+const manifestPath = resolve(projectDir, '.nuxt/content/manifest.ts')
+
+const collectionMatchers = [
+  ['landing', path => path === 'index.yaml'],
+  ['user', path => path.startsWith('users/')],
+  ['snippet', path => path.startsWith('snippets/')],
+  ['page', path => path.startsWith('pages/')],
+  ['article', path => path.startsWith('blog/article/')],
+  ['team', path => path.startsWith('mannschaften/')],
+  ['tournament', path => path.startsWith('turniere/')],
+]
+
+const requiredFields = {
+  landing: ['hero'],
+  user: ['username'],
+}
+
+const fieldValidators = {
+  boolean: value => typeof value === 'boolean',
+  date: value => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value),
+  integer: value => Number.isInteger(value),
+  json: value => value !== undefined,
+  number: value => typeof value === 'number' && Number.isFinite(value),
+  string: value => typeof value === 'string',
+}
+
+async function findContentFiles(directory = contentDir) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...await findContentFiles(path))
+    }
+    else if (/\.(?:json|md|ya?ml)$/.test(entry.name)) {
+      files.push(path)
+    }
+  }
+
+  return files
+}
+
+function parseMarkdownFrontmatter(source) {
+  const match = source.replace(/^\uFEFF/, '').match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  return match ? parseYaml(match[1]) : {}
+}
+
+function parseContentFile(path, source) {
+  switch (extname(path)) {
+    case '.json':
+      return JSON.parse(source)
+    case '.md':
+      return parseMarkdownFrontmatter(source)
+    case '.yaml':
+    case '.yml':
+      return parseYaml(source)
+    default:
+      return {}
+  }
+}
+
+function resolveCollection(path) {
+  return collectionMatchers.find(([, matches]) => matches(path))?.[0]
+}
+
+function parseManifest(source) {
+  const marker = 'export default '
+  const start = source.indexOf(marker)
+
+  if (start === -1) {
+    throw new Error('Generated Nuxt Content manifest has an unexpected format.')
+  }
+
+  return JSON.parse(source.slice(start + marker.length))
+}
+
+const manifest = parseManifest(await readFile(manifestPath, 'utf8'))
+const errors = []
+const files = await findContentFiles()
+
+for (const file of files) {
+  const contentPath = relative(contentDir, file).replace(/\\/g, '/')
+  const collectionName = resolveCollection(contentPath)
+
+  if (!collectionName) {
+    errors.push(`${contentPath}: file is not assigned to a known collection.`)
+    continue
+  }
+
+  try {
+    const document = parseContentFile(file, await readFile(file, 'utf8')) || {}
+    const fields = manifest[collectionName]?.fields
+
+    if (!fields) {
+      errors.push(`${contentPath}: generated schema for collection "${collectionName}" is missing.`)
+      continue
+    }
+
+    for (const field of requiredFields[collectionName] || []) {
+      if (document[field] === undefined) {
+        errors.push(`${contentPath}: required field "${field}" is missing.`)
+      }
+    }
+
+    for (const [field, value] of Object.entries(document)) {
+      const type = fields[field]
+
+      if (!type) {
+        errors.push(`${contentPath}: field "${field}" is not declared in the ${collectionName} collection schema.`)
+        continue
+      }
+
+      const validate = fieldValidators[type]
+
+      if (!validate) {
+        errors.push(`${contentPath}: generated field type "${type}" for "${field}" is not supported by the validator.`)
+      }
+      else if (!validate(value)) {
+        errors.push(`${contentPath}: field "${field}" must be ${type}, received ${Array.isArray(value) ? 'array' : typeof value}.`)
+      }
+    }
+  }
+  catch (error) {
+    errors.push(`${contentPath}: ${error.message}`)
+  }
+}
+
+if (errors.length) {
+  throw new Error(`Content schema validation failed:\n\n${errors.join('\n')}`)
+}
+
+console.log(`Validated ${files.length} content files against the generated Nuxt Content manifest.`)

--- a/scripts/validate-generated-output.mjs
+++ b/scripts/validate-generated-output.mjs
@@ -1,9 +1,44 @@
-import { readFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { access, readdir, readFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const publicDir = resolve(rootDir, '.output/public')
+
+async function assertPayloadReferences(directory = publicDir) {
+  const entries = await readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const filePath = resolve(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      await assertPayloadReferences(filePath)
+      continue
+    }
+
+    if (!entry.name.endsWith('.html')) {
+      continue
+    }
+
+    const html = await readFile(filePath, 'utf8')
+    const payloadSources = html.matchAll(/data-src="([^"?]*\/_payload\.json)(?:\?[^"?]*)?"/g)
+
+    for (const [, source] of payloadSources) {
+      const payloadPath = resolve(publicDir, source.replace(/^\/+/, ''))
+
+      try {
+        await access(payloadPath)
+      }
+      catch (error) {
+        if (error.code === 'ENOENT') {
+          throw new Error(`Generated HTML ${relative(publicDir, filePath)} references missing payload: ${source}`)
+        }
+
+        throw error
+      }
+    }
+  }
+}
 
 async function readRoute(route) {
   const candidates = route
@@ -59,4 +94,6 @@ for (const endpoint of endpoints) {
   }
 }
 
-console.log('Validated the generated site shell, legal routes, and public endpoints.')
+await assertPayloadReferences()
+
+console.log('Validated the generated site shell, legal routes, public endpoints, and payload references.')

--- a/scripts/validate-generated-output.mjs
+++ b/scripts/validate-generated-output.mjs
@@ -3,6 +3,7 @@ import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const contentDir = resolve(rootDir, 'content')
 const publicDir = resolve(rootDir, '.output/public')
 
 async function assertPayloadReferences(directory = publicDir) {
@@ -69,6 +70,78 @@ async function assertRoute(route, expected) {
   }
 }
 
+const searchableCollections = [
+  { directory: 'blog/article', routePrefix: '/blog/article' },
+  { directory: 'mannschaften', routePrefix: '/mannschaften' },
+  { directory: 'turniere', routePrefix: '/turniere' },
+]
+
+function stripOrderingPrefix(segment) {
+  return segment.replace(/^\d+\./, '')
+}
+
+async function findUnpublishedRoutes({ directory, routePrefix }) {
+  const collectionDir = resolve(contentDir, directory)
+  const routes = []
+
+  async function visit(currentDir) {
+    const entries = await readdir(currentDir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const filePath = resolve(currentDir, entry.name)
+
+      if (entry.isDirectory()) {
+        await visit(filePath)
+        continue
+      }
+
+      if (!/\.(?:md|ya?ml)$/.test(entry.name)) {
+        continue
+      }
+
+      const source = await readFile(filePath, 'utf8')
+      const statusLine = source.split(/\r?\n/).find(line => line.startsWith('status:'))
+      const status = statusLine
+        ?.slice('status:'.length)
+        .trim()
+        .replace(/^['"]/, '')
+        .replace(/['"]$/, '')
+
+      if (!status || status === 'published') {
+        continue
+      }
+
+      const route = relative(collectionDir, filePath)
+        .replace(/\\/g, '/')
+        .replace(/\.(?:md|ya?ml)$/, '')
+        .split('/')
+        .map(stripOrderingPrefix)
+        .join('/')
+
+      routes.push(`${routePrefix}/${route}`)
+    }
+  }
+
+  await visit(collectionDir)
+  return routes
+}
+
+async function assertSearchIndex() {
+  const sections = JSON.parse(await readFile(resolve(publicDir, 'api/search.json'), 'utf8'))
+  const ids = sections.map(section => section.id).filter(id => typeof id === 'string')
+
+  if (!ids.some(id => id === '/impressum' || id.startsWith('/impressum#'))) {
+    throw new Error('Generated search index does not contain the page collection.')
+  }
+
+  const unpublishedRoutes = (await Promise.all(searchableCollections.map(findUnpublishedRoutes))).flat()
+  const exposedRoute = unpublishedRoutes.find(route => ids.some(id => id === route || id.startsWith(`${route}#`)))
+
+  if (exposedRoute) {
+    throw new Error(`Generated search index exposes unpublished content: ${exposedRoute}`)
+  }
+}
+
 await assertRoute('', ['<header', '<main', '<footer', 'SF HN-Biberach'])
 await assertRoute('impressum', ['Impressum'])
 await assertRoute('datenschutz', ['Datenschutz'])
@@ -94,6 +167,7 @@ for (const endpoint of endpoints) {
   }
 }
 
+await assertSearchIndex()
 await assertPayloadReferences()
 
-console.log('Validated the generated site shell, legal routes, public endpoints, and payload references.')
+console.log('Validated the generated site shell, legal routes, published search index, public endpoints, and payload references.')

--- a/server/api/navigation.json.get.ts
+++ b/server/api/navigation.json.get.ts
@@ -7,7 +7,9 @@ export default defineEventHandler(async (event) => {
     queryCollectionNavigation(event, 'article')
       .where('status', '=', 'published')
       .order('date', 'DESC'),
-    queryCollectionNavigation(event, 'team'),
-    queryCollectionNavigation(event, 'tournament'),
+    queryCollectionNavigation(event, 'team')
+      .where('status', '=', 'published'),
+    queryCollectionNavigation(event, 'tournament')
+      .where('status', '=', 'published'),
   ]).then(data => data.flat())
 })

--- a/server/api/search.json.get.ts
+++ b/server/api/search.json.get.ts
@@ -3,8 +3,12 @@ import { queryCollectionSearchSections } from '@nuxt/content/server'
 
 export default defineEventHandler(async (event) => {
   return Promise.all([
-    queryCollectionSearchSections(event, 'article'),
-    queryCollectionSearchSections(event, 'team'),
-    queryCollectionSearchSections(event, 'tournament'),
+    queryCollectionSearchSections(event, 'page'),
+    queryCollectionSearchSections(event, 'article')
+      .where('status', '=', 'published'),
+    queryCollectionSearchSections(event, 'team')
+      .where('status', '=', 'published'),
+    queryCollectionSearchSections(event, 'tournament')
+      .where('status', '=', 'published'),
   ]).then(data => data.flat())
 })

--- a/server/api/teams/[slug].get.ts
+++ b/server/api/teams/[slug].get.ts
@@ -1,0 +1,25 @@
+import type { LeagueSource } from '../../../shared/types/league'
+import { queryCollection } from '@nuxt/content/server'
+
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+  if (!slug) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Team slug is required',
+    })
+  }
+
+  const page = await queryCollection(event, 'team')
+    .path(`/mannschaften/${slug}`)
+    .first()
+
+  if (!page || page.status !== 'published' || !page.league) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Team league data not found',
+    })
+  }
+
+  return getCachedLeagueTeam(event, page.league as LeagueSource)
+})

--- a/server/utils/league/fetchNuLiga.ts
+++ b/server/utils/league/fetchNuLiga.ts
@@ -1,0 +1,61 @@
+import type { H3Event } from 'h3'
+import type { LeagueSource } from '../../../shared/types/league'
+import { leagueSourceSchema, leagueTeamSnapshotSchema } from './schemas'
+
+const USER_AGENT = 'schachfreunde-biberach.de/1.0 (+https://schachfreunde-biberach.de/impressum)'
+const MAX_HTML_BYTES = 1_000_000
+
+async function fetchHtml(url: string) {
+  const response = await fetch(url, {
+    headers: {
+      'accept': 'text/html,application/xhtml+xml',
+      'user-agent': USER_AGENT,
+    },
+    signal: AbortSignal.timeout(8_000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`nuLiga responded with ${response.status} for ${url}`)
+  }
+
+  const contentLength = Number(response.headers.get('content-length') || 0)
+  if (contentLength > MAX_HTML_BYTES) {
+    throw new Error(`nuLiga response exceeds ${MAX_HTML_BYTES} bytes`)
+  }
+
+  const html = await response.text()
+  if (new TextEncoder().encode(html).byteLength > MAX_HTML_BYTES) {
+    throw new Error(`nuLiga response exceeds ${MAX_HTML_BYTES} bytes`)
+  }
+
+  return html
+}
+
+export async function fetchNuLigaTeam(sourceInput: LeagueSource) {
+  const source = leagueSourceSchema.parse(sourceInput)
+  const groupHtml = await fetchHtml(source.groupUrl)
+  const teamUrl = resolveNuLigaTeamUrl(groupHtml, source)
+  const teamHtml = await fetchHtml(teamUrl)
+
+  return leagueTeamSnapshotSchema.parse(parseNuLigaTeamPage(teamHtml, source, teamUrl))
+}
+
+function sourceCacheKey(source: LeagueSource) {
+  let hash = 2_166_136_261
+  const value = `${source.provider}|${source.season}|${source.groupUrl}|${source.teamName}`
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16_777_619)
+  }
+  return Math.abs(hash >>> 0).toString(36)
+}
+
+export const getCachedLeagueTeam = defineCachedFunction(
+  async (_event: H3Event, source: LeagueSource) => fetchNuLigaTeam(source),
+  {
+    name: 'nuliga-team',
+    maxAge: 6 * 60 * 60,
+    swr: true,
+    getKey: (_event: H3Event, source: LeagueSource) => sourceCacheKey(source),
+  },
+)

--- a/server/utils/league/fetchNuLiga.ts
+++ b/server/utils/league/fetchNuLiga.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import type { LeagueSource } from '../../../shared/types/league'
+import { LEAGUE_CACHE_MAX_AGE_SECONDS } from '../../../shared/constants/league'
 import { leagueSourceSchema, leagueTeamSnapshotSchema } from './schemas'
 
 const USER_AGENT = 'schachfreunde-biberach.de/1.0 (+https://schachfreunde-biberach.de/impressum)'
@@ -54,7 +55,7 @@ export const getCachedLeagueTeam = defineCachedFunction(
   async (_event: H3Event, source: LeagueSource) => fetchNuLigaTeam(source),
   {
     name: 'nuliga-team',
-    maxAge: 6 * 60 * 60,
+    maxAge: LEAGUE_CACHE_MAX_AGE_SECONDS,
     swr: true,
     getKey: (_event: H3Event, source: LeagueSource) => sourceCacheKey(source),
   },

--- a/server/utils/league/parseNuLiga.ts
+++ b/server/utils/league/parseNuLiga.ts
@@ -1,0 +1,209 @@
+import type { LeagueMatch, LeaguePlayer, LeagueSource, LeagueTeamSnapshot } from '../../../shared/types/league'
+import { load } from 'cheerio/slim'
+import { leagueTeamSnapshotSchema } from './schemas'
+
+const NULIGA_ORIGIN = 'https://svw-schach.liga.nu'
+type Document = ReturnType<typeof load>
+
+function normalizeText(value: string) {
+  return value.replace(/\u00A0/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function parseInteger(value: string) {
+  const normalized = normalizeText(value)
+  return /^\d+$/.test(normalized) ? Number.parseInt(normalized, 10) : undefined
+}
+
+function parseDate(value: string) {
+  const match = normalizeText(value).match(/^(\d{2})\.(\d{2})\.(\d{4})$/)
+  if (!match) {
+    throw new Error(`Unexpected nuLiga date: ${value}`)
+  }
+
+  return `${match[3]}-${match[2]}-${match[1]}`
+}
+
+function absoluteNuLigaUrl(href: string, baseUrl: string) {
+  const url = new URL(href, baseUrl)
+  if (url.origin !== NULIGA_ORIGIN) {
+    throw new Error(`Unexpected nuLiga origin: ${url.origin}`)
+  }
+
+  return url.toString()
+}
+
+function extractMeetingId(reportUrl: string | undefined, match: Omit<LeagueMatch, 'id'>) {
+  if (reportUrl) {
+    const meeting = new URL(reportUrl).searchParams.get('meeting')
+    if (meeting) {
+      return meeting
+    }
+  }
+
+  return [match.date, match.home, match.away].join(':')
+}
+
+function findMatchTable($: Document) {
+  return $('table.result-set').filter((_, table) => {
+    const headings = normalizeText($(table).find('th').text())
+    return headings.includes('Heimmannschaft') && headings.includes('Gastmannschaft')
+  }).first()
+}
+
+function parseMatches($: Document, sourceUrl: string): LeagueMatch[] {
+  const table = findMatchTable($)
+  if (!table.length) {
+    throw new Error('nuLiga match table not found')
+  }
+
+  const matches: LeagueMatch[] = []
+  table.find('tr').each((_, row) => {
+    if ($(row).find('th').length) {
+      return
+    }
+
+    const cells = $(row).find('td')
+    if (cells.length < 9) {
+      return
+    }
+
+    const dateText = normalizeText(cells.eq(1).text())
+    const home = normalizeText(cells.eq(6).text())
+    const away = normalizeText(cells.eq(7).text())
+    if (!dateText || !home || !away) {
+      return
+    }
+
+    const time = normalizeText(cells.eq(2).text()).match(/^\d{2}:\d{2}/)?.[0]
+    const round = normalizeText(cells.eq(4).text()) || undefined
+    const result = normalizeText(cells.eq(8).text()) || undefined
+    const reportHref = cells.eq(8).find('a[title="Spielbericht"]').attr('href')
+    const reportUrl = reportHref ? absoluteNuLigaUrl(reportHref, sourceUrl) : undefined
+    const partial: Omit<LeagueMatch, 'id'> = {
+      date: parseDate(dateText),
+      time,
+      round,
+      home,
+      away,
+      status: result ? 'finished' : 'scheduled',
+      result,
+      reportUrl,
+    }
+
+    matches.push({
+      id: extractMeetingId(reportUrl, partial),
+      ...partial,
+    })
+  })
+
+  return matches
+}
+
+function findPlayerTable($: Document) {
+  return $('table.result-set').filter((_, table) => {
+    const text = normalizeText($(table).text())
+    return text.includes('Stammspieler') && text.includes('Mitgliedsnummer')
+  }).first()
+}
+
+function parsePlayers($: Document): LeaguePlayer[] {
+  const table = findPlayerTable($)
+  if (!table.length) {
+    throw new Error('nuLiga player table not found')
+  }
+
+  const players: LeaguePlayer[] = []
+  let role: LeaguePlayer['role'] = 'starter'
+
+  table.find('tr').each((_, row) => {
+    const section = normalizeText($(row).find('b').text())
+    if (section === 'Stammspieler') {
+      role = 'starter'
+      return
+    }
+    if (section === 'Ersatzspieler') {
+      role = 'reserve'
+      return
+    }
+    if ($(row).find('th').length) {
+      return
+    }
+
+    const cells = $(row).find('td')
+    if (cells.length !== 6) {
+      return
+    }
+
+    const board = normalizeText(cells.eq(0).text())
+    const name = normalizeText(cells.eq(1).text())
+    if (!board || !name) {
+      return
+    }
+
+    players.push({
+      board,
+      name,
+      rating: parseInteger(cells.eq(3).text()),
+      role,
+      appearances: parseInteger(cells.eq(4).text()),
+      boardPoints: normalizeText(cells.eq(5).text()) || undefined,
+    })
+  })
+
+  return players
+}
+
+function parseCompetition($: Document) {
+  const headingHtml = $('h1').first().html()
+  if (!headingHtml) {
+    return undefined
+  }
+
+  const lines = headingHtml
+    .split(/<br\s*\/?>/i)
+    .map(line => normalizeText(load(line).text()))
+    .filter(Boolean)
+
+  return lines.at(1)
+}
+
+export function resolveNuLigaTeamUrl(groupHtml: string, source: LeagueSource) {
+  const groupUrl = new URL(source.groupUrl)
+  if (groupUrl.origin !== NULIGA_ORIGIN) {
+    throw new Error(`Unexpected nuLiga origin: ${groupUrl.origin}`)
+  }
+
+  const $ = load(groupHtml)
+  const link = $('a[title="Mannschaftsportrait"]').filter((_, element) => {
+    return normalizeText($(element).text()) === source.teamName
+  }).first()
+  const href = link.attr('href')
+  if (!href) {
+    throw new Error(`nuLiga team not found in group: ${source.teamName}`)
+  }
+
+  return absoluteNuLigaUrl(href, source.groupUrl)
+}
+
+export function parseNuLigaTeamPage(
+  teamHtml: string,
+  source: LeagueSource,
+  sourceUrl: string,
+  fetchedAt = new Date().toISOString(),
+): LeagueTeamSnapshot {
+  const $ = load(teamHtml)
+  const snapshot: LeagueTeamSnapshot = {
+    schemaVersion: 1,
+    sourceUrl,
+    fetchedAt,
+    season: source.season,
+    team: {
+      name: source.teamName,
+      competition: parseCompetition($),
+    },
+    players: parsePlayers($),
+    matches: parseMatches($, sourceUrl),
+  }
+
+  return leagueTeamSnapshotSchema.parse(snapshot)
+}

--- a/server/utils/league/schemas.ts
+++ b/server/utils/league/schemas.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+export const leagueSourceSchema = z.object({
+  provider: z.literal('nuliga'),
+  season: z.string().min(1),
+  groupUrl: z.url(),
+  teamName: z.string().min(1),
+})
+
+export const leagueTeamSnapshotSchema = z.object({
+  schemaVersion: z.literal(1),
+  sourceUrl: z.url(),
+  fetchedAt: z.iso.datetime(),
+  season: z.string().min(1),
+  team: z.object({
+    name: z.string().min(1),
+    competition: z.string().min(1).optional(),
+  }),
+  players: z.array(z.object({
+    board: z.string().min(1),
+    name: z.string().min(1),
+    rating: z.number().int().positive().optional(),
+    role: z.enum(['starter', 'reserve']),
+    appearances: z.number().int().nonnegative().optional(),
+    boardPoints: z.string().min(1).optional(),
+  })).min(1),
+  matches: z.array(z.object({
+    id: z.string().min(1),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    time: z.string().regex(/^\d{2}:\d{2}$/).optional(),
+    round: z.string().min(1).optional(),
+    home: z.string().min(1),
+    away: z.string().min(1),
+    status: z.enum(['scheduled', 'finished']),
+    result: z.string().min(1).optional(),
+    reportUrl: z.url().optional(),
+  })),
+})

--- a/shared/constants/league.ts
+++ b/shared/constants/league.ts
@@ -1,0 +1,7 @@
+export const LEAGUE_CACHE_MAX_AGE_SECONDS = 6 * 60 * 60
+export const LEAGUE_CACHE_MAX_AGE_MS = LEAGUE_CACHE_MAX_AGE_SECONDS * 1000
+
+export function isLeagueSnapshotStale(fetchedAt: string, now = Date.now()) {
+  const fetchedAtTime = Date.parse(fetchedAt)
+  return !Number.isFinite(fetchedAtTime) || now - fetchedAtTime >= LEAGUE_CACHE_MAX_AGE_MS
+}

--- a/shared/types/league.ts
+++ b/shared/types/league.ts
@@ -1,0 +1,40 @@
+export interface LeagueSource {
+  provider: 'nuliga'
+  season: string
+  groupUrl: string
+  teamName: string
+}
+
+export interface LeaguePlayer {
+  board: string
+  name: string
+  rating?: number
+  role: 'starter' | 'reserve'
+  appearances?: number
+  boardPoints?: string
+}
+
+export interface LeagueMatch {
+  id: string
+  date: string
+  time?: string
+  round?: string
+  home: string
+  away: string
+  status: 'scheduled' | 'finished'
+  result?: string
+  reportUrl?: string
+}
+
+export interface LeagueTeamSnapshot {
+  schemaVersion: 1
+  sourceUrl: string
+  fetchedAt: string
+  season: string
+  team: {
+    name: string
+    competition?: string
+  }
+  players: LeaguePlayer[]
+  matches: LeagueMatch[]
+}

--- a/tests/fixtures/nuliga-group.html
+++ b/tests/fixtures/nuliga-group.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="de">
+<body>
+  <table class="cross-table">
+    <tr><td><a title="Mannschaftsportrait" href="/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/teamPortrait?teamtable=100&amp;group=4211">Andere Mannschaft 1</a></td></tr>
+    <tr><td><a title="Mannschaftsportrait" href="/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/teamPortrait?teamtable=101&amp;group=4211">SF HN-Biberach 1</a></td></tr>
+  </table>
+</body>
+</html>

--- a/tests/fixtures/nuliga-team.html
+++ b/tests/fixtures/nuliga-team.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<body>
+  <h1>Württemberg 2025/26<br>Oberliga Württemberg<br>SF HN-Biberach 1978 e.V. 1. Mannschaft</h1>
+  <h2>Spieltermine</h2>
+  <table class="result-set">
+    <tr><th colspan="3">Tag Datum Zeit</th><th>Sportstätte</th><th>Runde</th><th>Nr.</th><th>Heimmannschaft</th><th>Gastmannschaft</th><th>Brettpunkte</th><th></th><th></th><th></th></tr>
+    <tr><td>So.</td><td>28.09.2025</td><td>10:00</td><td>(1)</td><td>1</td><td>4</td><td>Beispielverein 1</td><td>SF HN-Biberach 1</td><td><a title="Spielbericht" href="/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupMeetingReport?meeting=7001&amp;group=4211">3,5 : 4,5</a></td><td></td><td></td><td></td></tr>
+    <tr><td>So.</td><td>19.10.2025</td><td>09:30</td><td>(1)</td><td>2</td><td>12</td><td>SF HN-Biberach 1</td><td>Zweiter Beispielverein 1</td><td></td><td></td><td></td><td></td></tr>
+  </table>
+  <table class="result-set">
+    <tr><td colspan="6"><b>Stammspieler</b></td></tr>
+    <tr><th>Brett</th><th>Name, Vorname</th><th>Mitgliedsnummer</th><th>DWZ</th><th>Einsätze</th><th>Brettpunkte</th></tr>
+    <tr><td>1</td><td>Mustermann, Erika</td><td>999</td><td>2050</td><td>3</td><td>2,0 : 1,0</td></tr>
+    <tr class="table-split"><td colspan="6"><b>Ersatzspieler</b></td></tr>
+    <tr><th>Brett</th><th>Name, Vorname</th><th>Mitgliedsnummer</th><th>DWZ</th><th>Einsätze</th><th>Brettpunkte</th></tr>
+    <tr><td>9</td><td>Beispiel, Alex</td><td>998</td><td></td><td>1</td><td>0,5 : 0,5</td></tr>
+  </table>
+</body>
+</html>

--- a/tests/league-cache.test.ts
+++ b/tests/league-cache.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isLeagueSnapshotStale, LEAGUE_CACHE_MAX_AGE_MS } from '../shared/constants/league'
+
+describe('league cache freshness', () => {
+  const fetchedAt = '2026-07-13T08:00:00.000Z'
+  const fetchedAtTime = Date.parse(fetchedAt)
+
+  it('keeps snapshots fresh until the cache age is reached', () => {
+    expect(isLeagueSnapshotStale(fetchedAt, fetchedAtTime + LEAGUE_CACHE_MAX_AGE_MS - 1)).toBe(false)
+  })
+
+  it('revalidates snapshots at the cache age boundary', () => {
+    expect(isLeagueSnapshotStale(fetchedAt, fetchedAtTime + LEAGUE_CACHE_MAX_AGE_MS)).toBe(true)
+  })
+
+  it('revalidates snapshots with an invalid timestamp', () => {
+    expect(isLeagueSnapshotStale('invalid', fetchedAtTime)).toBe(true)
+  })
+})

--- a/tests/nuliga-parser.test.ts
+++ b/tests/nuliga-parser.test.ts
@@ -1,0 +1,44 @@
+import type { LeagueSource } from '../shared/types/league'
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+import { parseNuLigaTeamPage, resolveNuLigaTeamUrl } from '../server/utils/league/parseNuLiga'
+
+const source: LeagueSource = {
+  provider: 'nuliga',
+  season: '2025/26',
+  groupUrl: 'https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/groupPage?group=4211',
+  teamName: 'SF HN-Biberach 1',
+}
+
+const fixture = (name: string) => readFile(new URL(`./fixtures/${name}`, import.meta.url), 'utf8')
+
+describe('nuLiga parser', () => {
+  it('resolves the exact team portrait from a group page', async () => {
+    const url = resolveNuLigaTeamUrl(await fixture('nuliga-group.html'), source)
+    expect(url).toBe('https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/teamPortrait?teamtable=101&group=4211')
+  })
+
+  it('parses matches and players into the public snapshot contract', async () => {
+    const sourceUrl = 'https://svw-schach.liga.nu/cgi-bin/WebObjects/nuLigaSCHACHDE.woa/wa/teamPortrait?teamtable=101&group=4211'
+    const snapshot = parseNuLigaTeamPage(await fixture('nuliga-team.html'), source, sourceUrl, '2026-07-12T10:00:00.000Z')
+
+    expect(snapshot.team).toEqual({ name: 'SF HN-Biberach 1', competition: 'Oberliga Württemberg' })
+    expect(snapshot.matches).toEqual([
+      expect.objectContaining({ id: '7001', date: '2025-09-28', time: '10:00', status: 'finished', result: '3,5 : 4,5' }),
+      expect.objectContaining({ date: '2025-10-19', status: 'scheduled' }),
+    ])
+    expect(snapshot.players).toEqual([
+      { board: '1', name: 'Mustermann, Erika', rating: 2050, role: 'starter', appearances: 3, boardPoints: '2,0 : 1,0' },
+      { board: '9', name: 'Beispiel, Alex', role: 'reserve', appearances: 1, boardPoints: '0,5 : 0,5' },
+    ])
+    expect(snapshot.players[0]).not.toHaveProperty('memberNumber')
+  })
+
+  it('fails closed when the configured team is missing', async () => {
+    const groupHtml = await fixture('nuliga-group.html')
+    expect(() => resolveNuLigaTeamUrl(groupHtml, {
+      ...source,
+      teamName: 'Nicht vorhanden',
+    })).toThrow('nuLiga team not found')
+  })
+})


### PR DESCRIPTION
Adds live competition data to the team pages, including player lineups, upcoming fixtures and completed results from nuLiga.

The data is fetched and validated server-side, then cached for six hours. A responsive tabbed interface separates matches from the team lineup, while the lineup remains directly accessible through `?bereich=aufstellung`.

The Cloudflare deployment includes the D1 binding required by Nuxt Content and a persistent KV cache for nuLiga responses.

Closes #8.