### PR TITLE
fix(deploy): prevent Nuxt asset preload bursts

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -84,6 +84,16 @@ export default defineNuxtConfig({
     },
   },
 
+  hooks: {
+    'build:manifest': (manifest) => {
+      for (const chunk of Object.values(manifest)) {
+        if (chunk.resourceType === 'script') {
+          chunk.preload = false
+        }
+      }
+    },
+  },
+
   eslint: {
     config: {
       stylistic: true,


### PR DESCRIPTION
## Summary

This addresses the intermittent `503 Service Unavailable` responses for hashed Nuxt assets seen in production.

The generated homepage previously emitted 77 `modulepreload` hints, causing the browser to request a large part of the client bundle at once. The PR uses Nuxt's official `build:manifest` hook to disable eager JavaScript preloads. The Nuxt entry script remains unchanged, and its dependencies continue to load normally through the native ES module graph.

The Cloudflare asset binding and long-lived cache headers remain unchanged; the fix only removes the unnecessary initial request burst.