### PR TITLE
feat(blog): add hannes-hellriegel-ist-vereinsmeister-2026

### DIFF
--- a/content/blog/article/20260703.hannes-hellriegel-ist-vereinsmeister-2026.md
+++ b/content/blog/article/20260703.hannes-hellriegel-ist-vereinsmeister-2026.md
@@ -1,0 +1,51 @@
+---
+title: Hannes Hellriegel ist Vereinsmeister 2026
+authors:
+  - hubert-warsitz
+category: Verein
+date: 2026-07-03
+description: Hannes Hellriegel gewinnt die Vereinsmeisterschaft 2026 ungeschlagen mit 6,5 Punkten aus sieben Partien vor Thomas Hess.
+published: true
+sitemap:
+  loc: /blog/article/hannes-hellriegel-ist-vereinsmeister-2026
+tournament: vereinsmeisterschaft
+---
+
+Mit einem eindrucksvollen Start-Ziel-Sieg hat sich das 13-jährige Nachwuchstalent Hannes Hellriegel die Vereinsmeisterschaft 2026 der Schachfreunde HN-Biberach gesichert. In dem mit 24 Teilnehmern stark besetzten Turnier blieb der Kaderspieler über alle sieben Runden ungeschlagen und gewann mit hervorragenden 6,5 Punkten aus 7 Partien den Titel.
+
+Für Spannung bis zur letzten Runde sorgte Thomas Hess, der ebenfalls unbesiegt blieb und mit 5,5 Punkten den zweiten Platz belegte. Drei Remis verhinderten jedoch den ganz großen Wurf. Punktgleich, aber aufgrund der Feinwertung auf Rang drei, landete Spielleiter Dr. Hubert Warsitz. Nach einer überraschenden Niederlage gegen Jugendspieler Jan Hirth in der dritten Runde kämpfte er sich mit einer starken Turnierleistung noch auf das Siegerpodest vor.
+
+Auf den weiteren Plätzen folgten Harald Siegmann mit 5 Punkten sowie der amtierende Vereinsmeister des Vorjahres, Prof. Dr. Ole Wartlick, der sich diesmal mit Rang fünf und 4,5 Punkten begnügen musste.
+
+Besonders erfreulich war die starke Vorstellung der Jugendspieler. Neben dem neuen Vereinsmeister Hannes Hellriegel erreichten auch Nils Voßenberg, Valentin Hauk, Jan Hirth, Lucas Walburg und weitere Nachwuchsspieler beachtliche Ergebnisse und unterstrichen die erfolgreiche Jugendarbeit der Schachfreunde HN-Biberach. Die Vereinsmeisterschaft 2026 zeigte damit eindrucksvoll, dass die Zukunft des Vereins in guten Händen liegt.
+
+## Endstand nach sieben Runden
+
+In den Rundenspalten stehen das Ergebnis sowie die Nummer des Gegners und die Farbe. Dabei bedeutet `w` Weiß, `s` Schwarz und `k` kampflos.
+
+| Rang | Spieler | Pkt. | B_I | B_II | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+| ---: | :--- | ---: | ---: | ---: | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| 1 | Hannes Hellriegel | 6.5 | 28.5 | 185.5 | 1 (15s) | 1 (9w) | 1 (12s) | 1 (5w) | 1 (13s) | 1 (4w) | ½ (2s) |
+| 2 | Thomas Hess | 5.5 | 29.0 | 192.5 | 1 (13s) | ½ (3w) | ½ (4s) | 1 (20w) | 1 (6s) | 1 (15w) | ½ (1w) |
+| 3 | Dr. Hubert Warsitz | 5.5 | 24.0 | 166.0 | 1 (24w) | ½ (2s) | 0 (8w) | 1 (16s) | 1 (5w) | 1 (14s) | 1 (11w) |
+| 4 | Harald Siegmann | 5.0 | 28.5 | 173.0 | ½ (5s) | 1 (23w) | ½ (2w) | 1 (8s) | 1 (14w) | 0 (1s) | 1 (7w) |
+| 5 | Dr. Ole Wartlick | 4.5 | 27.0 | 180.0 | ½ (4w) | 1 (24s) | 1 (14w) | 0 (1s) | 0 (3s) | 1 (13w) | 1 (6s) |
+| 6 | Nils Voßenberg | 4.0 | 26.5 | 175.0 | 1 (19w) | 0 (14s) | 1 (17w) | 1 (7s) | 0 (2w) | 1 (8s) | 0 (5w) |
+| 7 | Valentin Hauk | 4.0 | 24.0 | 185.5 | 1 (16s) | 0 (13w) | 1 (15s) | 0 (6w) | 1 (20s) | 1 (10w) | 0 (4s) |
+| 8 | Jan Hirth | 4.0 | 24.0 | 171.5 | 0 (23s) | 1k (20w) | 1 (3s) | 0 (4w) | 1 (12s) | 0 (6w) | 1 (13s) |
+| 9 | Markus Holzinger | 4.0 | 22.0 | 165.0 | 1 (18w) | 0 (1s) | 0 (20s) | 0 (10s) | 1 (22w) | 1 (19w) | 1 (15s) |
+| 10 | Lucas Walburg | 4.0 | 21.5 | 164.5 | 0 (20s) | 0 (16w) | 1 (18w) | 1 (9w) | 1 (19s) | 0 (7s) | 1 (14w) |
+| 11 | Yevhenii Levchenko | 4.0 | 19.0 | 164.0 | 0 (17w) | 1 (19s) | 1 (22w) | 0 (13w) | 1 (21s) | 1 (20w) | 0 (3s) |
+| 12 | Finn Holzinger | 3.5 | 22.5 | 160.5 | 1 (22w) | 1 (18s) | 0 (1w) | 0 (14s) | 0 (8w) | ½ (17s) | 1 (21s) |
+| 13 | David Ilnizki | 3.0 | 29.5 | 163.5 | 0 (2w) | 1 (7s) | 1k (23w) | 1 (11s) | 0 (1w) | 0 (5s) | 0 (8w) |
+| 14 | Emil Hauk | 3.0 | 28.5 | 167.5 | 1 (21s) | 1 (6w) | 0 (5s) | 1 (12w) | 0 (4s) | 0 (3w) | 0 (10s) |
+| 15 | Rudolf Marschall | 3.0 | 27.0 | 172.0 | 0 (1w) | 1 (17s) | 0 (7w) | 1 (22s) | 1 (16w) | 0 (2s) | 0 (9w) |
+| 16 | Maximillian Heckmann | 3.0 | 24.0 | 156.5 | 0 (7w) | 1 (10s) | ½ (19w) | 0 (3w) | 0 (15s) | 1 (21w) | ½ (17s) |
+| 17 | Jan Voßenberg | 3.0 | 22.5 | 154.0 | 1 (11s) | 0 (15w) | 0 (6s) | 0 (21w) | 1 (18s) | ½ (12w) | ½ (16w) |
+| 18 | Andreas Hellriegel | 3.0 | 17.5 | 139.0 | 0 (9s) | 0 (12w) | 0 (10s) | 1k | 0 (17w) | 1 (22s) | 1k (20w) |
+| 19 | Waldemar Warsitz | 2.5 | 20.0 | 149.5 | 0 (6s) | 0 (11w) | ½ (16s) | 1 (24s) | 0 (10w) | 0 (9s) | 1 (22w) |
+| 20 | Sudiksha Narayana | 2.0 | 28.5 | 157.0 | 1 (10w) | 0k (8s) | 1 (9w) | 0 (2s) | 0 (7w) | 0 (11s) | 0k (18s) |
+| 21 | Emma Hellriegel | 2.0 | 17.5 | 153.0 | 0 (14w) | 0 (22s) | 1 (24w) | 1 (17s) | 0 (11w) | 0 (16s) | 0 (12w) |
+| 22 | Alexander Noe | 1.0 | 22.0 | 145.5 | 0 (12s) | 1 (21w) | 0 (11s) | 0 (15w) | 0 (9s) | 0 (18w) | 0 (19s) |
+| 23 | Luka M. Panic | 1.0 | 12.0 | 82.0 | 1 (8w) | 0 (4s) | 0k (13s) |  |  |  |  |
+| 24 | Detlef Offergeld | 0.0 | 14.5 | 88.5 | 0 (3s) | 0 (5w) | 0 (21s) | 0 (19w) |  |  |  |


### PR DESCRIPTION
Adds `content/blog/article/20260703.hannes-hellriegel-ist-vereinsmeister-2026.md` with the full 2026 club championship report and a semantic 24-player standings table transcribed from the supplied PDF. Links the article to the existing Vereinsmeisterschaft tournament page.