### PR TITLE
feat(blog): add unterlaender-schachtage-2023

### DIFF
--- a/content/blog/article/20230730.unterlaender-schachtage-2023.md
+++ b/content/blog/article/20230730.unterlaender-schachtage-2023.md
@@ -1,0 +1,24 @@
+---
+title: Unterländer Schachtage 2023
+authors:
+  - dimitrios-triantafillidis
+category: Verein
+date: 2023-07-30
+description: "205 Teilnehmer bei den 4. Unterländer Schachtagen: Siege für Koellner, Kuschmann und Sahin."
+published: true
+sitemap:
+  loc: /blog/article/unterlaender-schachtage-2023
+tournament: internationale-unterlaender-schachtage
+---
+
+Ende Juli – wie immer zu Beginn der Schulferien in Baden-Württemberg – heißt es „Schach in Biberach“, in Form der „Internationalen Unterländer Schachtage“ – dieses Jahr in der bereits 4. Auflage. Vier Tage lang lieferten sich über 200 Teilnehmer über sieben Runden hinweg spannende Duelle.
+
+Im A-Turnier gab sich Elofavorit IM Ruben Gideon Koellner (SF Deizisau) keine Blöße und siegte mit 6 Punkten und damit einem halben Punkt Vorsprung vor FM Enis Zuferi und FM Simon Degenhard (beide Heilbronner SchV). Knapp dahinter konnten sich Pascal Neukirchner (SK Gründau), Christof Koellner (SF Deizisau) und Lokalmatador Jens Hoffmann (Sfr. HN-Biberach) noch in die Preisgeldränge spielen. Den Mannschaftspreis gewann die Mannschaft des Ausrichters, die Sfr. HN-Biberach.
+
+Im B-Turnier gab es jede Menge Überraschungen. Souveräner Sieger wurde der an 19 gesetzte Enkenbacher Klaus Kuschmann mit 6 Punkten. C-Turnier-Vorjahressieger Ilia Vinogradov (SV Walldorf) wurde 2. mit einem halben Punkt Rückstand. Ebenfalls 5,5 Punkte hatten die 3. und 4. platzierten Lukas Eitel (SF Plochingen) und Felix Käfer (Botvinnik Steinsfurt). Auch diese Spieler überraschten mit tollen Leistungen, waren sie doch in der Startrangliste deutlich tiefer gesetzt als ihre Endplatzierung. Von den top-gesetzten Spielern konnte lediglich Uwe Rautenberg (SC Ingersheim) seine Startranglistensetzung bestätigen und landete mit 5 Punkten, punktgleich mit Fabian Junge (SK Marburg), noch in den Preisrängen. Der Mannschaftspreis ging knapp auch in dieser Sektion an die Heimmannschaft der Sfr. HN-Biberach, knapp vor Öhringen und den SF Schwaigern.
+
+Beim C-Turnier gönnte sich Furkan Huseyin Sahin (vereinslos) in der letzten Runde ein schnelles Remis, was ihn zum Sieger mit überlegenen 6,5 Punkten in der C-Sektion kürte. 2. wurde Paul Käfer (SC Künzelsau) vor Maximilian Guo (SF Pattonville) und Kai Bogatzki (vereinslos), alle mit jeweils 5,5 Punkten. Als 5. schaffte es noch Julian Tittmann (vom Verein mit dem coolsten Namen, meiner Meinung nach, den fuß brothers Jena) in die Preisränge. Den Mannschaftspreis der 4 besten Spieler konnten sich im C-Turnier die Spieler der Karlsruher Schachfreunde mit deutlichem Vorsprung vor den Sfr. HN-Biberach sichern.
+
+Alles in allem lief das Turnier aus Ausrichtersicht hervorragend. Bestes Schachwetter über 4 Tage sorgte dafür, dass es in der Halle nicht allzu heiß wurde. Die Partien verliefen alle komplikationsfrei und die Schiedsrichter hatten lediglich 4–5 Mal Situationen am Brett zu entscheiden, die recht friedlich zu lösen waren. In der 4. Auflage der Internationalen Unterländer Schachtage gab es einen Teilnehmerrekord, bei dem die magische Grenze von 200 Spielern erstmals überschritten wurde. Mit am Ende 205 Teilnehmern aus zahlreichen Ländern (Indien, Griechenland, Canada, Ungarn etc.) freuen wir uns schon jetzt sehr auf das kleine Jubiläum im nächsten Jahr, wenn es dann vom 25.–28. Juli 2024 heißen wird: Willkommen zu den 5. IUST 2024 😊
+
+Herzlichen Glückwunsch an die Sieger! Wir bedanken uns für die rege Teilnahme und freuen uns auf das nächste Jahr!


### PR DESCRIPTION
Adds the report on the 4th International Unterländer Chess Days in 2023.

Article: `content/blog/article/20230730.unterlaender-schachtage-2023.md`.