### PR TITLE
feat(blog): add reachable Wayback articles

### DIFF
--- a/content/blog/article/20211016.11-biber-jugend-cup-2021-ergebnisse.md
+++ b/content/blog/article/20211016.11-biber-jugend-cup-2021-ergebnisse.md
@@ -25,19 +25,16 @@ Der 11. Biber-Jugend-Cup fand mit etwa 130 Teilnehmern in der Böllingertalhalle
 
 Jüngste Teilnehmerin war die vierjährige Meara Classen. Bestes Team wurde der Heilbronner SV, größtes Team der SC Neckarsulm.
 
-## Downloads
+## Fehlende Archivdateien
 
-- [Ergebnistabelle U8](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U8-Kreuz-R7.html)
-- [Ergebnistabelle U10](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U10-Fort-R7.html)
-- [Ergebnistabelle U12](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U12-Fort-R7.html)
-- [Ergebnistabelle U14](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U14-Fort-R7.html)
-- [Ergebnistabelle U25 B](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U25B-Fort-R7.html)
-- [Ergebnistabelle U25 A](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U25A-Fort-R7.html)
-- [Sonderwertung „beste Mannschaft“](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Auswertung%20Sonderpreise%202021%20beste%20Mannschaft.pdf)
-- [Sonderwertung „größte Mannschaft“](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Auswertung%20Sonderpreise%202021%20gr%C3%B6%C3%9Fte%20Mannschaft%20.pdf)
+Die ursprünglich verlinkten Ergebnistabellen und Sonderwertungen sind im Webarchiv nicht mehr abrufbar.
+
+<!-- WAYBACK-ASSET-FEHLT: Ergebnistabellen U8, U10, U12, U14, U25 B und U25 A sowie Sonderwertungen beste und größte Mannschaft. -->
 
 ## Impressionen
 
-[Zur archivierten Fotogalerie](https://web.archive.org/web/20250512221238/https://photos.app.goo.gl/EyqF2KVENw1VCTJD7)
+Die ursprünglich eingebundenen Turnierfotos und die Fotogalerie sind im Webarchiv nicht mehr abrufbar.
+
+<!-- WAYBACK-ASSET-FEHLT: Zwölf Turnierfotos und externe Google-Fotogalerie des 11. Biber-Jugend-Cups 2021. -->
 
 Vielen Dank an alle Helfer und Teilnehmer. Wir hoffen auf ein Wiedersehen beim 12. Biber-Jugend-Cup.

--- a/content/blog/article/20211016.11-biber-jugend-cup-2021-ergebnisse.md
+++ b/content/blog/article/20211016.11-biber-jugend-cup-2021-ergebnisse.md
@@ -1,0 +1,43 @@
+---
+title: "11. Biber-Jugend-Cup 2021: Ergebnisse"
+category: Jugend
+date: 2021-10-16
+description: Rund 130 Kinder und Jugendliche spielen beim 11. Biber-Jugend-Cup in sechs Altersklassen um die Turniersiege.
+published: false
+sitemap:
+  loc: /blog/article/11-biber-jugend-cup-2021-ergebnisse
+toc: true
+tournament: biber-jugend-cup
+---
+
+Der 11. Biber-Jugend-Cup fand mit etwa 130 Teilnehmern in der Böllingertalhalle statt. Der ursprünglich geplante Frühjahrstermin war wegen Corona ausgefallen. Der Herbsttermin wurde erst rund zwei Wochen vorher genehmigt. Es galten kontrollierte 3G-Regeln.
+
+## Ergebnisse
+
+- **U8:** Samuel Epp gewann mit fünf Punkten aus sieben Runden vor Leonard Jüngling und Aumkar Sriram.
+- **U10:** Leonard Peter gewann mit 7/7. Ilia Vinogradov wurde Zweiter vor Lucas Stummvoll. Hannes Hellriegel belegte Rang 15, Hannah Fischer Rang 18.
+- **U12:** David Koryakin gewann. Leonard Wylie wurde Zweiter, Niklas Jung Dritter. Henry Fischer kam auf Rang 10, Erik Epp auf Rang 20.
+- **U14:** Magnus Epp gewann vor Roman Weinhold und Adrian Mühlbauer. Rodrigo Melzig wurde Fünfter, Mathilde Faff Zwanzigste.
+- **U25 B:** Johannes Stahl gewann mit sieben Punkten vor Erol Hasanov und Sriram Iyengar.
+- **U25 A:** Simon Degenhard gewann mit 7/7 vor Kevin Broncel und Nicolas Messerschmidt. Jonas Martsfeld wurde Elfter.
+
+## Sonderpreise
+
+Jüngste Teilnehmerin war die vierjährige Meara Classen. Bestes Team wurde der Heilbronner SV, größtes Team der SC Neckarsulm.
+
+## Downloads
+
+- [Ergebnistabelle U8](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U8-Kreuz-R7.html)
+- [Ergebnistabelle U10](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U10-Fort-R7.html)
+- [Ergebnistabelle U12](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U12-Fort-R7.html)
+- [Ergebnistabelle U14](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U14-Fort-R7.html)
+- [Ergebnistabelle U25 B](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U25B-Fort-R7.html)
+- [Ergebnistabelle U25 A](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Biber-Jugend-Cup%202021%20U25A-Fort-R7.html)
+- [Sonderwertung „beste Mannschaft“](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Auswertung%20Sonderpreise%202021%20beste%20Mannschaft.pdf)
+- [Sonderwertung „größte Mannschaft“](https://web.archive.org/web/20250512221238/http://www.schachfreunde-biberach.schachvereine.de/userfiles/downloads/turniere/bibercup_2021/Auswertung%20Sonderpreise%202021%20gr%C3%B6%C3%9Fte%20Mannschaft%20.pdf)
+
+## Impressionen
+
+[Zur archivierten Fotogalerie](https://web.archive.org/web/20250512221238/https://photos.app.goo.gl/EyqF2KVENw1VCTJD7)
+
+Vielen Dank an alle Helfer und Teilnehmer. Wir hoffen auf ein Wiedersehen beim 12. Biber-Jugend-Cup.

--- a/content/blog/article/20211023.erwachsenen-schachkurs-am-27-10.md
+++ b/content/blog/article/20211023.erwachsenen-schachkurs-am-27-10.md
@@ -1,0 +1,26 @@
+---
+title: Erwachsenen-Schachkurs am 27.10.
+category: Verein
+date: 2021-10-23
+description: Die Schachfreunde bieten ab dem 27. Oktober 2021 einen fünfwöchigen Kurs für erwachsene Anfänger und Wiedereinsteiger an.
+published: false
+sitemap:
+  loc: /blog/article/erwachsenen-schachkurs-am-27-10
+toc: true
+---
+
+Die Schachfreunde HN-Biberach bieten einen Kurs für erwachsene Anfänger und Wiedereinsteiger an. Beginn ist am Mittwoch, 27. Oktober 2021, um 18 Uhr.
+
+## Kursinhalt
+
+An fünf Abenden werden unter der damals geltenden 3G-Regelung die Schachregeln und Begriffe wie Matt, Patt, Zugzwang und Rochade erklärt.
+
+Der Kurs findet wöchentlich im Vereinsraum in der Grundschule Heilbronn-Biberach neben dem Hallenbad im 1. Stock statt. Jede Einheit dauert zweimal 45 Minuten. Die Kursgebühr beträgt 25 Euro.
+
+## Anmeldung
+
+Die damalige Anmeldung war bei Eric Hermann telefonisch unter 0162 5797614, per E-Mail an [Schachkurs@Schachfreunde-Biberach.de](mailto:Schachkurs@Schachfreunde-Biberach.de) oder direkt vor Ort möglich.
+
+## Flyer
+
+[Archivierten Kursflyer als PDF öffnen](https://web.archive.org/web/20250717003944/http://schachfreunde-biberach.schachvereine.de/userfiles/downloads/termine/SchachF%C3%BCrEinsteiger20210921%20Alternative%202.pdf)

--- a/content/blog/article/20211023.erwachsenen-schachkurs-am-27-10.md
+++ b/content/blog/article/20211023.erwachsenen-schachkurs-am-27-10.md
@@ -23,4 +23,6 @@ Die damalige Anmeldung war bei Eric Hermann telefonisch unter 0162 5797614, per 
 
 ## Flyer
 
-[Archivierten Kursflyer als PDF öffnen](https://web.archive.org/web/20250717003944/http://schachfreunde-biberach.schachvereine.de/userfiles/downloads/termine/SchachF%C3%BCrEinsteiger20210921%20Alternative%202.pdf)
+Der ursprünglich verlinkte Kursflyer ist im Webarchiv nicht mehr abrufbar.
+
+<!-- WAYBACK-ASSET-FEHLT: PDF-Kursflyer zum Erwachsenen-Schachkurs ab 27. Oktober 2021. -->

--- a/content/blog/article/20211031.tg-forchtenberg-1-sf-hn-biberach-2.md
+++ b/content/blog/article/20211031.tg-forchtenberg-1-sf-hn-biberach-2.md
@@ -1,0 +1,17 @@
+---
+title: TG Forchtenberg 1 - SF HN-Biberach 2
+category: Mannschaft
+date: 2021-10-31
+description: Nach langer Wettkampfpause startet die zweite Mannschaft mit einem deutlichen 7:1-Erfolg bei der TG Forchtenberg 1.
+published: false
+sitemap:
+  loc: /blog/article/tg-forchtenberg-1-sf-hn-biberach-2
+---
+
+Endlich ging es nach der ausgefallenen Saison und langer Turnierpause wieder an die Bretter. Markus Holzinger kehrte nach mehreren Zwischenstationen zurück. Magnus Epp gab nach einem Trainingsjahr sein Debüt in einer Mannschaft. Beide erwiesen sich als erfolgreiche Neuzugänge.
+
+Nach fast anderthalb Jahren ohne Wettkampfpraxis war die aktuelle Spielstärke schwer einzuschätzen. Biberach war nominell Favorit, lag aber nach Patricks Niederlage an Brett 1 zunächst mit 0:1 zurück. Armin glich an Brett 5 aus, Gerald brachte Biberach um 12 Uhr mit 2:1 in Führung.
+
+Anschließend ging es Schlag auf Schlag: Innerhalb von drei Minuten gewannen Robin, Dimi und Markus ihre Partien. Damit stand es 5:1 für Biberach.
+
+René gewann seine interessante Stellung und Magnus setzte sich nach mehr als vier Stunden ebenfalls durch. Am Ende stand ein verdienter, wenn auch vielleicht etwas zu hoch ausgefallener 7:1-Sieg.

--- a/content/blog/article/20211113.sf-hn-biberach-1-sc-ingersheim-1.md
+++ b/content/blog/article/20211113.sf-hn-biberach-1-sc-ingersheim-1.md
@@ -1,0 +1,21 @@
+---
+title: SF HN-Biberach 1 - SC Ingersheim 1
+authors:
+  - hubert-warsitz
+category: Mannschaft
+date: 2021-11-13
+description: Trotz dreier Ausfälle gewinnt HN-Biberach 1 den Landesliga-Mannschaftskampf gegen den SC Ingersheim 1 mit 4,5:3,5.
+published: false
+sitemap:
+  loc: /blog/article/sf-hn-biberach-1-sc-ingersheim-1
+---
+
+Die 1. Mannschaft der Schachfreunde bekam es in der Landesliga mit dem DWZ-mäßig zweitstärksten Team, dem SC Ingersheim 1, zu Hause zu tun. Die Vorzeichen waren nicht besonders gut: Drei der stärksten Spieler waren verhindert und mussten ersetzt werden. Es war also mannschaftliche Geschlossenheit verlangt.
+
+Markus Holzinger erspielte sich an Brett 7 in einem Dame-Springer-Endspiel einen entfernten Mehrbauern. Nach etwa drei Stunden und 15 Minuten erreichte Hubert Warsitz ein Remis. Kurz darauf folgte Oliver Zeyer mit einem Remis bei ungleichfarbigen Läufern.
+
+Dimi Triantafillidis wurde um 12:33 Uhr mattgesetzt. Damit stand es 1:2. Vier Minuten später remisierte Thomas Hess zum Zwischenstand von 1,5:2,5.
+
+Eugen Holzinger konnte eine zunächst verlorene Stellung noch in ein Remis verwandeln. Anschließend gewann Markus Holzinger seine Partie mithilfe seines Freibauern, ehe Alexander Arns remisierte. Beim Stand von 3,5:3,5 entschied die letzte Partie den Mannschaftskampf.
+
+Philipp Müller gewann an Brett 1 mit einem weit vorgerückten Freibauern und sicherte der Mannschaft den 4,5:3,5-Sieg. Eine starke geschlossene Mannschaftsleistung vor der nächsten Herausforderung gegen Bad Wimpfen.

--- a/content/blog/article/20220117.sf-hn-biberach-1-sf-hn-biberach-2.md
+++ b/content/blog/article/20220117.sf-hn-biberach-1-sf-hn-biberach-2.md
@@ -1,0 +1,28 @@
+---
+title: SF HN-Biberach 1 - SF HN-Biberach 2
+category: Jugend
+date: 2022-01-17
+description: Zum Start der Verbandsjugendliga setzt sich Biberach 1 mit 5,5:0,5 gegen die zweite Jugendmannschaft durch.
+published: false
+sitemap:
+  loc: /blog/article/sf-hn-biberach-1-sf-hn-biberach-2
+---
+
+Zum Start der diesjährigen Verbandsjugendliga (VJL) trafen Biberach 1 und Biberach 2 aufeinander. Nachdem die letzte Saison ausgefallen war und unsere 1. Mannschaft vorletztes Jahr den bitteren Abstieg aus der Jugendbundesliga antreten musste, traf sie am heutigen ersten Spieltag der neuen Saison auf die 2. Mannschaft unseres Vereins. Diese wiederum hatte es geschafft, aus der Bezirksjugendliga in die VJL aufzusteigen. Auf dem Papier ein etwas ungleiches Duell, aber die Zweite wollte durchaus kräftig Paroli bieten, ist doch das erklärte Ziel, die Liga zu halten.
+
+Gleich zu Beginn gab es allerdings schon zwei unerfreuliche Absagen in letzter Sekunde, sodass der Favorit, sobald die Uhren gedrückt waren, bereits mit 2:0 in Front war. Die anderen vier Partien verliefen spannend, waren gut umkämpft, aber am Ende setzte sich jeweils der Favorit am Brett durch, sodass ein 6:0 oder 0:6, je nach Standpunkt, zu Buche stand … dachten zumindest alle. Aber bei der letzten Partie an Brett 1 schaffte es Jonas nach über drei Stunden Spielzeit in klarer Gewinnstellung, seinen Gegner Sriram patt zu setzen :-)
+
+Mit dieser Schlusspointe konnte die Zweite dann doch den Ehrenzähler erzielen, auch wenn es nur ein halber war.
+
+## Es spielten
+
+| Biberach 1 | Biberach 2 | Ergebnis |
+| --- | --- | :---: |
+| Jonas | Sriram | 0,5:0,5 |
+| René | Rodrigo | +:- |
+| Robin | Baran | 1:0 |
+| Henry | Kadir | +:- |
+| David | Julius | 1:0 |
+| Hannes | Sudiksha | 1:0 |
+
+Der nächste Spieltag findet im Februar statt. Dann spielen unsere Mannschaften gegen Forchtenberg (die Erste) und gegen Hohentübingen (die Zweite).

--- a/content/blog/article/20220117.vjl-sf-hn-biberach-1-sf-hn-biberach-2.md
+++ b/content/blog/article/20220117.vjl-sf-hn-biberach-1-sf-hn-biberach-2.md
@@ -5,7 +5,7 @@ date: 2022-01-17
 description: Zum Start der Verbandsjugendliga setzt sich Biberach 1 mit 5,5:0,5 gegen die zweite Jugendmannschaft durch.
 published: false
 sitemap:
-  loc: /blog/article/sf-hn-biberach-1-sf-hn-biberach-2
+  loc: /blog/article/vjl-sf-hn-biberach-1-sf-hn-biberach-2
 ---
 
 Zum Start der diesjährigen Verbandsjugendliga (VJL) trafen Biberach 1 und Biberach 2 aufeinander. Nachdem die letzte Saison ausgefallen war und unsere 1. Mannschaft vorletztes Jahr den bitteren Abstieg aus der Jugendbundesliga antreten musste, traf sie am heutigen ersten Spieltag der neuen Saison auf die 2. Mannschaft unseres Vereins. Diese wiederum hatte es geschafft, aus der Bezirksjugendliga in die VJL aufzusteigen. Auf dem Papier ein etwas ungleiches Duell, aber die Zweite wollte durchaus kräftig Paroli bieten, ist doch das erklärte Ziel, die Liga zu halten.

--- a/content/blog/article/20220225.sf-hn-biberach-1-tsv-willsbach-1.md
+++ b/content/blog/article/20220225.sf-hn-biberach-1-tsv-willsbach-1.md
@@ -1,0 +1,19 @@
+---
+title: SF HN-Biberach 1 - TSV Willsbach 1
+category: Mannschaft
+date: 2022-02-25
+description: HN-Biberach 1 gewinnt das Nachholspiel gegen den TSV Willsbach 1 souverän mit 6:2 und übernimmt vorübergehend die Tabellenführung.
+published: false
+sitemap:
+  loc: /blog/article/sf-hn-biberach-1-tsv-willsbach-1
+---
+
+Gestern holten wir die Begegnung gegen den TSV Willsbach 1 aus der Landesligarunde 4 nach. Wir bestritten unser Heimspiel in Willsbach – ein Zugeständnis, nachdem wir vor einigen Wochen wegen Coronafällen in unseren eigenen Reihen kurzfristig abgesagt hatten. Mit 6:2 fuhren wir einen souveränen Sieg ein.
+
+Zunächst gewann Hubert am achten Brett nach etwas über einer Stunde, ehe Simeon an 5 in gedrückter Stellung ins Remis einwilligte und Oli an 2 erstickt matt setzte sowie Noah an 3 sein Endspiel souverän und mit taktischem Witz nach Hause spielte. Nach drei Stunden stellte Philipps Gegner am vordersten Brett eine Figur ein, als dieser den Druck erhöhte. Damit hatten wir den Zwischenstand 4,5:0,5 und den Mannschaftskampf schon für uns entschieden.
+
+Die Fortsetzung der restlichen Partien war dann ein Auf und Ab. Zunächst hatte Jens an 4 einen kleinen, nicht entscheidenden strategischen Vorteil im Doppel-Turmendspiel. Alex an 6 lehnte das Remisangebot seines Gegners zu Recht ab, wonach dieser ein nachteiliges Ungleichgewicht erzeugte. Eugen hatte derweil mit Qualität mehr und Mehrbauer an 7 alles unter Kontrolle. Jens und Alex hatten mal wieder etwas Zeitnot, Eugen einen kleinen Blackout, als er seinen angegriffenen Turm nicht wegzog. Zwischenzeitlich munkelten ein paar, dass wir die restlichen drei Partien noch verlören, wenn es so weiterginge.
+
+Eugen wickelte aber in ein Remis ab und Alex brachte einen entfernten Freibauern gekonnt zur Umwandlung. Hierbei stand er nie kritisch, das einzig Aufgeregte waren die nervösen Zuschauer. Jens unterlag nach langem Hin und Her final seinem Gegner. Schade, dass wir nicht verlustpunktfrei blieben, aber eine gute Lehre war die Partie allemal.
+
+Somit ist HN-Biberach 1 jetzt vorübergehend Tabellenführer und es zeigt sich dabei sehr viel angriffslustiger als die anderen Mannschaften, die noch im Winterschlaf stecken und irgendwann im Frühling ihre Nachholpartien geballt spielen dürften.

--- a/content/blog/article/20220326.sf-hn-biberach-2-sv-bad-friedrichshall-1.md
+++ b/content/blog/article/20220326.sf-hn-biberach-2-sv-bad-friedrichshall-1.md
@@ -1,0 +1,15 @@
+---
+title: SF HN-Biberach 2 - SV Bad Friedrichshall 1
+category: Mannschaft
+date: 2022-03-26
+description: Die zweite Mannschaft erkämpft sich gegen den starken SV Bad Friedrichshall 1 ein wichtiges 4:4.
+published: false
+sitemap:
+  loc: /blog/article/sf-hn-biberach-2-sv-bad-friedrichshall-1
+---
+
+Gegen Bad Friedrichshall ging es für unsere Mannschaft darum, möglichst ihre guten Chancen auf den Aufstieg zu wahren. Doch leider konnten wir nicht in Bestbesetzung antreten, sodass Zoé nach langer Zeit Schachabstinenz mal wieder an die Bretter musste. Bad Friedrichshall ist nicht so gut in die Saison gestartet, ist aber nominell eine sehr starke Mannschaft, die etwas unter ihren Möglichkeiten in der Kreisklasse gerade unterwegs ist. Konzentriert ging es also zu Werke.
+
+Patrick (1) kam nicht gut aus der Eröffnung und machte es seinem Gegner etwas zu einfach, sodass es nach bereits zwei Stunden 0:1 stand. Auch bei Gerald (3) sah es nicht gut aus und er musste nach 2,5 Stunden aufgeben. Besser machte es Zoé (8), die ihren Springer anbot, der aber vergiftet war. Dadurch konnte sie ihren Bauern durchbringen und auf 1:2 verkürzen. Dimi (7) konnte gegen Gerd Retzbach nicht den vollen Punkt einfahren, sodass es nach drei Stunden 1,5:2,5 stand.
+
+Spannung dafür an den anderen Brettern. Jonas (5) lehnte ein erstes Remisangebot richtigerweise ab, konnte aber seinen Vorteil nicht zum vollen Punkt ummünzen. Das zweite Remisangebot musste er dann sogar annehmen, um nicht in ein verlorenes Endspiel abzuwickeln, und es stand 2:3. Markus konnte trotz Figurrückstand einen Freibauern so weit vorrücken, dass er das Spiel gewann. Super Partie! 3:3. Es spielten noch Robin (6) in verlorener Stellung und René (4) in unklarer Stellung. Aber Robin verteidigte wie ein Großmeister und hielt die Partie remis, sodass René beruhigt das Remisangebot annehmen konnte. Ein 4:4 stand am Ende zu Buche, mit dem beide Mannschaften zufrieden sein konnten.

--- a/content/blog/article/20220412.bjem-2022.md
+++ b/content/blog/article/20220412.bjem-2022.md
@@ -1,0 +1,21 @@
+---
+title: BJEM 2022
+category: Jugend
+date: 2022-04-12
+description: Hannah Fischer wird Bezirksmeisterin der U10w und qualifiziert sich gemeinsam mit Hannes Hellriegel für die WJEM.
+published: false
+sitemap:
+  loc: /blog/article/bjem-2022
+---
+
+Mit insgesamt fünf Spielern fuhren wir zur BJEM U8–U12 nach Schwäbisch Hall. In der U8 hätten wir mit Samuel Epp sicher ein heißes Eisen im Feuer gehabt, aber Corona verhinderte ärgerlicherweise seinen Start. Das sorgte dafür, dass auch sein Bruder Erik leider nicht teilnehmen konnte. Unsere U10-Starterin Sudiksha hatte zu Wochenbeginn leider auch schon abgesagt, sodass wir „nur“ fünf Spieler stellten. Diese spielten aber richtig gutes Schach.
+
+Nach spannenden sieben Runden hieß es Platz 1 und damit Bezirksmeisterin in der U10w: Hannah Fischer, die mit vier Punkten ein super Ergebnis einfuhr. Ebenfalls vier Punkte erreichten Anton Geltz, der ein super Turnier spielte, und David Ilnizki, der etwas unter seinen Erwartungen blieb. Hannes Hellriegel verpasste bei seiner ersten BJEM knapp das Siegerpodest und landete mit fünf Punkten auf Platz 4.
+
+Damit qualifizierten sich Hannah und Hannes für die WJEM, die nach Ostern in Stuttgart stattfinden wird. Herzlichen Glückwunsch!
+
+In der U12 musste Hannahs Bruder Henry bis zur letzten Partie zittern, um zu erfahren, ob er mit seiner Schwester zur WJEM mitfahren durfte. Nach langem Zittern hieß es auch für Henry leider, dass die Qualifikation um einen Platz verpasst wurde.
+
+Alles in allem haben unsere Jungs und Mädels aber richtig gut Schach gespielt und das Ergebnis mit zwei Qualifikationsplätzen, davon eine Meisterin, kann sich sehen lassen.
+
+Damit komplettieren Hannah und Hannes unsere älteren Spieler Mathilde, Noah, Robin, Sriram und Magnus, die dann nach Ostern die WJEM spielen werden. Wir wünschen allen Spielern viel Erfolg!

--- a/content/blog/article/20220423.sf-hn-biberach-2-sc-bt-bad-wimpfen-2.md
+++ b/content/blog/article/20220423.sf-hn-biberach-2-sc-bt-bad-wimpfen-2.md
@@ -1,0 +1,17 @@
+---
+title: SF HN-Biberach 2 - SC BT Bad Wimpfen 2
+category: Mannschaft
+date: 2022-04-23
+description: Die zweite Mannschaft gewinnt beim Nachholspiel gegen Bad Wimpfen 2 vorläufig mit 6:0 und übernimmt die Tabellenführung.
+published: false
+sitemap:
+  loc: /blog/article/sf-hn-biberach-2-sc-bt-bad-wimpfen-2
+---
+
+Beim Nachholspiel in der Kreisklasse zwischen unserer 2. Mannschaft und der 2. aus Bad Wimpfen erwischten die Biber einen Sahnetag.
+
+Bereits nach 45 Minuten brachte Armin (4) uns mit 1:0 in Führung. Alle anderen Partien liefen gut an und jeder kam auch gut aus der Eröffnung. Gegen 11:15 Uhr konnte Markus J. (8) einen Freibauern auf der g-Linie bilden, der seinen Gegner zur Aufgabe zwang. Kurze Zeit später streckte auch Renés (3) Gegner die Waffen und es stand 3:0. Als Dimi (6) dann auf 4:0 erhöhte, roch es schon nach einem Kantersieg für Biberach. Markus H. (2) erhöhte auf 5:0 mit einer sehenswerten Partie, bei der er die Dame für zwei Türme und eine Leichtfigur gab. Jetzt spielte nur noch Patrick (1) unter dem Druck, die Weste reinzuhalten. Peu à peu knetete er seine Stellung und nachdem beide Spieler jeweils einmal ein Remisangebot abgelehnt hatten, gewann Patrick um kurz nach 12 Uhr seine Partie zum vorläufigen 6:0-„Endstand“.
+
+Die zwei Partien an den Brettern 5 (Robin) und 7 (Magnus) werden noch nachgespielt, da die beiden auf der WJEM in Lindau spielten. Wir drücken den beiden die Daumen.
+
+Durch diesen Sieg hat sich unsere 2. Mannschaft nun endgültig oben in der Tabelle festgesetzt und geht punktgleich, aber mit einem Brettpunkt mehr als Bad Rappenau, als Tabellenführer in die letzten beiden Spiele der Saison.

--- a/content/blog/article/20220425.wjem-2022.md
+++ b/content/blog/article/20220425.wjem-2022.md
@@ -1,0 +1,26 @@
+---
+title: WJEM 2022
+category: Jugend
+date: 2022-04-25
+description: Hannes Hellriegel gewinnt die U10, Noah Geltz wird Vizemeister der U18 und die Biber überzeugen bei der WJEM 2022.
+published: false
+sitemap:
+  loc: /blog/article/wjem-2022
+toc: true
+---
+
+## WJEM der U10/U10w in Stuttgart
+
+Osterzeit ist WJEM-Zeit. Endlich fanden sie wieder statt: die beliebten Württembergischen Meisterschaften der Jugend, dieses Jahr an zwei Orten. Die älteren (U14–U18) spielten in Lindau, die jüngeren (U8–U12) in Stuttgart. Bei den Kleinen hatten sich über die BJEM vier Spieler/-innen qualifiziert, die die Farben der Biber sehr würdig vertraten.
+
+In der U10 gelang es Hannes Hellriegel sogar, bei seiner ersten WJEM alle anderen Spieler hinter sich zu lassen und den Titel „Württembergischer Meister U10m“ zu gewinnen! Beherztes und konzentriertes Spiel über drei Tage war die Voraussetzung dafür. Herzlichen Glückwunsch! Aber auch die anderen Starter zeigten sich von ihrer Sonnenseite. David Ilnizki erreichte den 6. Platz. Auch er zeigte sich deutlich verbessert im Vergleich zur BJEM vor zwei Wochen. David spielte ein super Turnier und beide Spieler werden einen guten Sprung in ihrer DWZ machen. Die beiden Mädchen Hannah Fischer und Sudiksha Narayana spielten ebenfalls großartiges Schach und erreichten beide vier Punkte. Am Ende waren sie punktgleich mit der Drittplatzierten und wurden Vierte und Sechste.
+
+Damit fährt Hannes zur Deutschen Einzelmeisterschaft, die vom 4. bis 12. Juni in Willingen stattfinden wird. Nochmals herzlichen Glückwunsch!
+
+## WJEM der U14–U18 in Lindau
+
+In Lindau gingen die älteren Kinder und Jugendlichen an den Start. Und auch hier haben wir tolle Teilnehmer ins Rennen geschickt. Die Jüngsten waren dort unsere U14er. Mit Magnus Epp und Mathilde Faff traten dort zwei Spieler an, die ihre erste Teilnahme an einer WJEM feiern durften. Beide machten ihre Sache sehr gut und gingen mit 3,5 (Magnus) und 1,5 Punkten (Mathilde) aus dem Rennen. Magnus schaffte es sogar in die Top Ten und wurde Zehnter. Mathilde rutschte knapp an einer Top-Ten-Platzierung vorbei und wurde Elfte. Sriram Iyengar ging in der U16 für Biberach auf Punktejagd und auch er konnte sehr zufrieden mit seinem Abschneiden sein. Mit vier Punkten wurde Sriram Zwölfter. In der U18 hatten wir mit Noah Geltz und Robin Gerold gleich zwei Spieler im Rennen. Bei Robin lief es im ganzen Turnier nicht so wie erhofft, aber gegen Ende konnte er noch einmal zeigen, dass er zu Recht auf der WJEM ist. Robin wurde mit 2,5 Punkten Sechzehnter. Äußerst knapp am Titel vorbei schrammte Noah Geltz. Niederlagenfrei bei nur zwei Remisen musste er punktgleich mit Alexander Chen, den er in Runde 5 besiegen konnte, lange auf das Buchholzergebnis warten. Leider war das Glück nicht auf Biberacher Seite und Noah wurde äußerst knapp Vizemeister. Trotzdem Glückwunsch für die super Leistung!
+
+Alles in allem konnten die Biber sehr zufrieden mit dem Abschneiden sein. Ein Titel, einmal die Vizemeisterschaft und mit dem 4. Platz eine hauchdünn am Treppchen vorbeigeschrammte Platzierung sowie weitere gute Ergebnisse können sich wirklich sehen lassen.
+
+Die Biber haben gezeigt, dass sie die Corona-Zeit gut genutzt und fleißig an den Brettern trainiert haben. Hannes drücken wir auf der DEM ganz fest die Daumen und freuen uns schon auf viele weitere Turniere.

--- a/content/blog/article/20220709.sf-hn-biberach-1-sk-bebenhausen-2.md
+++ b/content/blog/article/20220709.sf-hn-biberach-1-sk-bebenhausen-2.md
@@ -1,0 +1,15 @@
+---
+title: SF HN-Biberach 1 - SK Bebenhausen 2
+category: Jugend
+date: 2022-07-09
+description: Die erste Jugendmannschaft besiegt Bebenhausen 2 mit 5,5:0,5 und steigt wieder in die Jugendbundesliga Süd auf.
+published: false
+sitemap:
+  loc: /blog/article/sf-hn-biberach-1-sk-bebenhausen-2
+---
+
+Erfahrungsgemäß lässt Bebenhausen keine Bretter frei. Auch wenn es für sie um nichts mehr ging, war es dann aber doch überraschend, dass nur vier Spieler anreisten. Somit lagen wir schnell mit 2:0 in Führung und brauchten noch einen Brettpunkt, um den für den Aufstieg und die Meisterschaft letzten Mannschaftspunkt zu erspielen.
+
+Normalerweise macht unsere Truppe es sehr spannend, doch dieses Mal konnten wir schnell aufhören zu zittern. Bereits nach einer Stunde gelang es René an Brett 3, mit einem sehenswerten Matt auf 3:0 zu erhöhen. In diesem Moment waren wir endlich wieder in die JBL aufgestiegen! Die restlichen Partien verliefen auch recht einseitig, sodass am Ende ein nie gefährdeter 5,5:0,5-Sieg zu verbuchen war. Lediglich Jonas gab nach knapp drei Stunden ein Remis, nachdem er seine Eröffnung nicht sehr gut gespielt hatte.
+
+Unsere erste Jugendmannschaft steigt somit nach einer Saison Abstinenz – eigentlich waren es zwei Jahre, aber unter Corona wurde eine Saison nicht gespielt – wieder in die Jugendbundesliga Süd auf. Herzlichen Glückwunsch!


### PR DESCRIPTION
Reconstructs eleven reachable archive articles from 2021 and 2022 in the current Nuxt Content format. Every article remains unpublished with `published: false`; unavailable result files, photos, and the course flyer are documented with the searchable `WAYBACK-ASSET-FEHLT` marker instead of broken archive links. The historical VJL report uses a unique route to avoid colliding with the published 2025 report.

## Completed articles

- [x] SF HN-Biberach 1 - SK Bebenhausen 2
- [x] WJEM 2022
- [x] SF HN-Biberach 2 - SC BT Bad Wimpfen 2
- [x] BJEM 2022
- [x] SF HN-Biberach 2 - SV Bad Friedrichshall 1
- [x] SF HN-Biberach 1 - TSV Willsbach 1
- [x] VJL: SF HN-Biberach 1 - SF HN-Biberach 2
- [x] SF HN-Biberach 1 - SC Ingersheim 1
- [x] TG Forchtenberg 1 - SF HN-Biberach 2
- [x] Erwachsenen-Schachkurs am 27.10.
- [x] 11. Biber-Jugend-Cup 2021: Ergebnisse

Relates to #11.