### PR TITLE
feat(blog): add unterlaender-schachtage-2025

### DIFF
--- a/content/blog/article/20250731.unterlaender-schachtage-2025.md
+++ b/content/blog/article/20250731.unterlaender-schachtage-2025.md
@@ -1,0 +1,41 @@
+---
+title: Unterländer Schachtage 2025
+authors:
+  - dimitrios-triantafillidis
+category: Verein
+date: 2025-07-31
+description: "244 Spieler bei den 6. Unterländer Schachtagen: Doll, Fröhlich und Jacque gewinnen die Turniere."
+published: true
+sitemap:
+  loc: /blog/article/unterlaender-schachtage-2025
+toc: true
+tournament: internationale-unterlaender-schachtage
+---
+
+Ende Juli – wie immer zu Beginn der Schulferien in Baden-Württemberg – heißt es „Schach in Biberach“, in Form der „Internationalen Unterländer Schachtage“.
+
+Vom 31. Juli bis zum 3. August trafen sich in der Böllingertalhalle in Heilbronn-Biberach vier Tage lang 244 Schachspieler schon zum 6. Mal, um sich über sieben Runden hinweg spannende Duelle zu liefern. Aber natürlich kamen auch das Fachsimpeln, das Kiebitzen und der Austausch unter den Schachspielern nicht zu kurz.
+
+Im A-Turnier konnten gleich fünf Spieler ohne Niederlage bleiben, sodass in solchen Fällen immer die Anzahl der Remisen relevant ist. Das Turnier gewinnen konnte mit 6 Punkten Alexander Doll (SC Untergrombach), vor Simon Degenhard (Heilbronner SV), der ebenfalls 6 Punkte erspielte, aber die leicht schlechtere Buchholz hatte. Elo-Favorit GM Oleg Korneev landete mit 5,5 Punkten auf dem 3. Platz.
+
+Auch das B-Turnier war spannend bis zur letzten Runde. Hier gewann mit 6,5 Punkten Moritz Fröhlich vom SC Eppingen vor der ebenfalls niederlagenfreien Marina Heil von den SF Wetzisreute. Beide lagen vor einem Pulk aus vier Spielern, die jeweils einen halben Punkt weniger hatten. Die beste Feinwertung dieser vier hatte Kostiantyn Kravchenko vom SK Sandhausen.
+
+Der Mannschaftspreis im B-Turnier ging hauchzart an die Ausrichter der Sfr. HN-Biberach, die einen halben Punkt mehr sammeln konnten als das Team vom SV Walldorf.
+
+Das spannendste Turnier war das C-Turnier, bei dem sich die vier Führenden direkt duellierten: 1 gegen 2 und 3 gegen 4. Alle vier wollten das Turnier gewinnen, sodass es spannend bis zum Ende blieb. Die Spannung blieb bis zur Siegerehrung erhalten, da alle vier Partien remis endeten. Das C-Turnier gewinnen konnte letzten Endes mit 5,5 Punkten und lediglich einem halben Buchholzsummenpunkt mehr, also der 2. Feinwertung, Maurice Jacque vor Sriram Vasu. Genauso knapp war der Abstand zwischen Platz 3 und 4. Hier konnte sich Johannes Ruhland den letzten Podestplatz sichern. Vierter wurde Maik Zabel.
+
+Den Mannschaftspreis der vier besten Spieler konnten sich im C-Turnier die Spieler der Sfr. HN-Biberach sichern.
+
+Alles in allem lief das Turnier aus Ausrichtersicht hervorragend. Bestes Schachwetter über vier Tage sorgte dafür, dass es in der Halle gute Bedingungen gab. Die Spieler konnten sich in den Pausen mit gegrillten Steaks, Würsten, aber auch mit anderen Speisen stärken.
+
+Die Partien verliefen alle komplikationsfrei und die Schiedsrichter hatten lediglich vier- bis fünfmal Situationen am Brett zu entscheiden, die recht friedlich zu lösen waren.
+
+Dass die Internationalen Unterländer Schachtage weiterhin am Wachsen sind, zeigte die erneute Rekordteilnehmerzahl, bei der wir zum ersten Mal an unsere Kapazitätsgrenzen gehen mussten. 244 Spieler fanden 2025 den Weg zu den Schachfreunden HN-Biberach. Es musste sogar einigen Spielern abgesagt werden, die sich gerne den 244 Teilnehmern angeschlossen hätten. Wir werden versuchen, dem Rechnung zu tragen und im kommenden Jahr die Kapazitätsgrenze – wenn möglich – zu erhöhen, sodass jeder Spieler, der teilnehmen möchte, teilnehmen kann.
+
+Wir freuen uns schon jetzt sehr auf die 7. Auflage im nächsten Jahr, wenn es dann vom 31. Juli bis 3. August 2026 heißen wird:
+
+Willkommen zu den 7. IUST 2026 😊
+
+Herzlichen Glückwunsch an die Sieger! Wir bedanken uns für die rege Teilnahme und freuen uns auf das nächste Jahr!
+
+Alle Ergebnisse zum Nachlesen und viele tolle Bilder findet ihr hier: [Unterländer Schachtage](https://www.unterlaender-schachtage.de/)


### PR DESCRIPTION
Adds the 2025 report for the 6th Internationale Unterländer Schachtage, including the tournament results, record participation, and outlook for 2026. Article: `20250731.unterlaender-schachtage-2025.md`. Uses the existing tournament link and no new media assets.