### PR TITLE
feat(blog): add unterlaender-schachtage-2026

### DIFF
--- a/content/blog/article/20260730.unterlaender-schachtage-2026.md
+++ b/content/blog/article/20260730.unterlaender-schachtage-2026.md
@@ -1,0 +1,63 @@
+---
+title: Rekordbeteiligung und beste Werbung für den Schachsport – 7. Internationale Unterländer Schachtage
+authors:
+  - dimitrios-triantafillidis
+category: Verein
+date: 2026-07-30
+description: "259 Teilnehmer aus zehn Nationen sorgen bei den 7. Unterländer Schachtagen für einen neuen Rekord und spannende Turniertage."
+published: true
+sitemap:
+  loc: /blog/article/unterlaender-schachtage-2026
+toc: true
+tournament: internationale-unterlaender-schachtage
+---
+
+Mit den 7. Internationalen Unterländer Schachtagen haben die Schachfreunde Heilbronn-Biberach 1978 e. V. ihre bislang größte und erfolgreichste Turnierveranstaltung durchgeführt. Vom 30. Juli bis zum 2. August 2026 wurde die Böllingertalhalle vier Tage lang zum Treffpunkt für Schachspieler aller Alters- und Leistungsklassen. Trotz der hochsommerlichen Temperaturen und einiger kurzfristiger hitzebedingter Absagen konnten insgesamt 259 Teilnehmer begrüßt werden – ein neuer Teilnehmerrekord.
+
+Das Turnier wurde wie in den vergangenen Jahren in drei Leistungsklassen ausgetragen. Im offenen A-Turnier gingen 129 Spieler an den Start, darunter vier FIDE-Meister und zwei Candidate Master. Im B-Turnier für Spieler mit einer DWZ unter 1800 kämpften 82 Teilnehmer um Punkte und Preisgelder, während das C-Turnier für Spieler mit einer DWZ unter 1400 mit 48 Teilnehmern ebenfalls hervorragend besetzt war. Gespielt wurden jeweils sieben Runden nach Schweizer System mit Fischer-Bedenkzeit.
+
+Dass sich die Unterländer Schachtage längst weit über die Region hinaus einen ausgezeichneten Ruf erworben haben, zeigte erneut das internationale Teilnehmerfeld. Neben Spielern aus ganz Deutschland waren Teilnehmer aus Indien, der Türkei, Frankreich, den Niederlanden, Luxemburg, der Schweiz, der Ukraine, Taiwan und Australien vertreten. Die endgültigen Platzierungen in allen drei Turnieren fielen erst in der Schlussrunde, was die große Ausgeglichenheit der Teilnehmerfelder eindrucksvoll unterstrich.
+
+## A-Turnier
+
+Im hervorragend besetzten A-Turnier setzte sich FM Veaceslav Cofmann (SC Eppingen) mit 6,5 Punkten ungeschlagen durch. Zweiter wurde Laurin Haufe (SG Turm Albstadt) mit 6 Punkten vor FM Esat Tuna Türker (Heilbronner SV), der sich mit der besseren Buchholzwertung Rang drei sicherte.
+
+Aus Sicht der Gastgeber ragte Philipp Müller heraus. Mit 5,5 Punkten erreichte er einen ausgezeichneten fünften Platz und behauptete sich in der Spitzengruppe des Turniers. Ebenfalls starke Leistungen zeigten Hannes Hellriegel, Jens Hoffmann und Robin Gerold, die jeweils 3,5 Punkte erzielten.
+
+Neben den Hauptpreisen wurden zahlreiche Sonderpreise vergeben. Die Damenwertung gewann Marina Heil, während Seyyid Cilo (U14) und Guillaume Garde (U18) die Jugendwertungen für sich entschieden. Die Ratingpreise gingen an Nachiket Dhonnar (unter 1976 DWZ) und Maximilian Steigleder (unter 2104 DWZ). Bester Senior wurde Ralf Hein. In der Mannschaftswertung setzte sich der SK Münster 32 vor den SF 59 Kornwestheim und den gastgebenden Schachfreunden Heilbronn-Biberach durch.
+
+## B-Turnier
+
+Das B-Turnier gewann Marnin Classen (SV Riegelsberg) mit 6,5 Punkten vor Florian Kretz (SK Mühlhausen) und Felix Bauer.
+
+Für die Schachfreunde Heilbronn-Biberach überzeugte besonders Markus Holzinger, der mit 4,5 Punkten einen hervorragenden 14. Platz belegte. Harald Siegmann erreichte Rang 19 und durfte sich zusätzlich über den dritten Platz in der Seniorenwertung freuen.
+
+Die Sonderwertungen spiegelten die große Leistungsdichte des Turniers wider. Luana Hermann gewann den Damenpreis. Die Jugendwertungen gingen an Samarth Gadamshetty (U10), Benjamin Schade (U12) und Mick Jussack (U14). Die Ratingpreise sicherten sich Swadesh Prasad Hegde (unter 1720 DWZ) und Emrah Duran (unter 1816 DWZ). Bei den Senioren setzte sich Klaus Kuschmann vor Manfred Hannemann und Harald Siegmann durch. Besonders erfreulich aus Sicht der Gastgeber war der Gewinn der Mannschaftswertung durch die Schachfreunde Heilbronn-Biberach.
+
+## C-Turnier
+
+Im C-Turnier setzte sich Clara Hollmeier (SF Heidelberg) mit 6,5 Punkten souverän durch. Til Lippert wurde Zweiter, während Lucas Walburg mit ebenfalls 5,5 Punkten einen hervorragenden dritten Platz belegte und damit das beste Ergebnis eines Biberacher Spielers erzielte.
+
+Auch zahlreiche Nachwuchsspieler der Schachfreunde sammelten wertvolle Turniererfahrung. Finn Holzinger erreichte mit vier Punkten Rang zwölf. Emma Hellriegel, Valentin Hauk und Waldemar Warsitz erzielten jeweils 3,5 Punkte. Besonders bemerkenswert waren dabei die fünf Remis von Waldemar Warsitz gegen teilweise deutlich höher eingestufte Gegner.
+
+Die Sonderpreise im C-Turnier gingen an Caroline Schade (U10), Emma Hellriegel (U12), Ralf Kau (Rating unter 1400) sowie Jason Sapronov als bester Spieler ohne Wertungszahl. Der traditionelle DRK-Kreuzworträtselpreis wurde ebenfalls an Caroline Schade vergeben. In der Mannschaftswertung hatten die Gastgeber erneut Grund zur Freude: Die Schachfreunde Heilbronn-Biberach belegten den ersten Platz vor SK Appenweier und SC Blauer Turm Bad Wimpfen.
+
+## Ein großes Lob für Organisation und Helfer
+
+Neben den sportlichen Erfolgen erhielt die Organisation der Schachfreunde Heilbronn-Biberach viel Anerkennung. Gelobt wurden insbesondere die angenehmen Spielbedingungen, der reibungslose Ablauf, die preiswerte und abwechslungsreiche Verpflegung sowie die erstmals eingesetzten Namensschilder an allen Brettern, die von vielen Teilnehmern als deutliche Verbesserung hervorgehoben wurden.
+
+Ein Turnier dieser Größenordnung wäre ohne die Unterstützung der zahlreichen Helferinnen und Helfer nicht möglich gewesen. Ob Turnierleitung, Auslosung, Technik, Küche, Verkauf, Auf- und Abbau oder Vorbereitung der Spielsääle – an vielen Stellen engagierten sich Vereinsmitglieder und Freunde des Vereins mit großem Einsatz. Ihnen gilt ein herzliches Dankeschön.
+
+Die vielen positiven Rückmeldungen der Teilnehmer und die zahlreichen spontanen Zusagen für eine erneute Teilnahme im kommenden Jahr sind die schönste Anerkennung für die geleistete Arbeit. Mit einer Rekordbeteiligung, einem internationalen Teilnehmerfeld und einem rundum gelungenen Turnier haben sich die Unterländer Schachtage endgültig als eines der bedeutendsten Schach-Open im süddeutschen Raum etabliert. Die Vorfreude auf die 8. Internationalen Unterländer Schachtage 2027 ist bereits jetzt groß.
+
+## Kurze Statistik
+
+- 259 Teilnehmer aus 10 Nationen
+- 129 / 82 / 48 Teilnehmer im A-, B- und C-Turnier
+- 7 Runden Schweizer System
+- 1.813 gespielte Partien
+- 6 Titelträger im A-Turnier
+- 5 Mannschaftspreise
+- 33 Sonderpreise
+- 4 Turniertage
+- über 40 Helferinnen und Helfer

--- a/content/blog/article/20260730.unterlaender-schachtage-2026.md
+++ b/content/blog/article/20260730.unterlaender-schachtage-2026.md
@@ -1,10 +1,10 @@
 ---
-title: Rekordbeteiligung und beste Werbung für den Schachsport – 7. Internationale Unterländer Schachtage
+title: 7. Internationale Unterländer Schachtage
 authors:
   - dimitrios-triantafillidis
 category: Verein
-date: 2026-07-30
-description: "259 Teilnehmer aus zehn Nationen sorgen bei den 7. Unterländer Schachtagen für einen neuen Rekord und spannende Turniertage."
+date: 2026-08-02
+description: "259 Teilnehmer aus zehn Nationen sorgen für einen neuen Rekord und spannende Turniertage"
 published: true
 sitemap:
   loc: /blog/article/unterlaender-schachtage-2026

--- a/content/blog/article/20260730.unterlaender-schachtage-2026.md
+++ b/content/blog/article/20260730.unterlaender-schachtage-2026.md
@@ -46,7 +46,7 @@ Die Sonderpreise im C-Turnier gingen an Caroline Schade (U10), Emma Hellriegel (
 
 Neben den sportlichen Erfolgen erhielt die Organisation der Schachfreunde Heilbronn-Biberach viel Anerkennung. Gelobt wurden insbesondere die angenehmen Spielbedingungen, der reibungslose Ablauf, die preiswerte und abwechslungsreiche Verpflegung sowie die erstmals eingesetzten Namensschilder an allen Brettern, die von vielen Teilnehmern als deutliche Verbesserung hervorgehoben wurden.
 
-Ein Turnier dieser Größenordnung wäre ohne die Unterstützung der zahlreichen Helferinnen und Helfer nicht möglich gewesen. Ob Turnierleitung, Auslosung, Technik, Küche, Verkauf, Auf- und Abbau oder Vorbereitung der Spielsääle – an vielen Stellen engagierten sich Vereinsmitglieder und Freunde des Vereins mit großem Einsatz. Ihnen gilt ein herzliches Dankeschön.
+Ein Turnier dieser Größenordnung wäre ohne die Unterstützung der zahlreichen Helferinnen und Helfer nicht möglich gewesen. Ob Turnierleitung, Auslosung, Technik, Küche, Verkauf, Auf- und Abbau oder Vorbereitung der Spielsäle – an vielen Stellen engagierten sich Vereinsmitglieder und Freunde des Vereins mit großem Einsatz. Ihnen gilt ein herzliches Dankeschön.
 
 Die vielen positiven Rückmeldungen der Teilnehmer und die zahlreichen spontanen Zusagen für eine erneute Teilnahme im kommenden Jahr sind die schönste Anerkennung für die geleistete Arbeit. Mit einer Rekordbeteiligung, einem internationalen Teilnehmerfeld und einem rundum gelungenen Turnier haben sich die Unterländer Schachtage endgültig als eines der bedeutendsten Schach-Open im süddeutschen Raum etabliert. Die Vorfreude auf die 8. Internationalen Unterländer Schachtage 2027 ist bereits jetzt groß.
 


### PR DESCRIPTION
Adds the report for the 7th International Unterländer Schachtage as `content/blog/article/20260730.unterlaender-schachtage-2026.md`, including the tournament metadata and results from all three sections. No additional assets were provided.