### PR TITLE
feat(blog): add offener-vereinsabend

### DIFF
--- a/content/blog/article/20260806.offener-vereinsabend.md
+++ b/content/blog/article/20260806.offener-vereinsabend.md
@@ -1,0 +1,24 @@
+---
+title: Gelungener Auftakt für den offenen Vereinsabend
+category: Verein
+date: 2026-08-06
+description: Beim ersten offenen Vereinsabend der Schachfreunde HN-Biberach kamen 18 Schachinteressierte in entspannter Atmosphäre zusammen.
+published: true
+sitemap:
+  loc: /blog/article/offener-vereinsabend
+toc: true
+---
+
+Am Freitag, 31. Juli, fand im Vereinsheim der Schachfreunde Heilbronn-Biberach erstmals ein offener Vereinsabend statt. Neben den Vereinsmitgliedern waren auch sieben Gäste dabei, die den Verein und seine Spielabende kennenlernen wollten. Insgesamt kamen 18 Schachinteressierte zusammen.
+
+## Schach in entspannter Atmosphäre
+
+Gespielt wurde ohne festen Turniermodus. Die Anwesenden konnten ihre Partien selbst organisieren, verschiedene Eröffnungen ausprobieren und sich zwischendurch über die laufenden Spiele austauschen. Gerade für die Gäste war das eine gute Gelegenheit, ohne Verpflichtung erste Partien mit Vereinsmitgliedern zu spielen.
+
+Auch abseits der Bretter blieb Zeit für Gespräche. Dabei ging es nicht nur um die gespielten Züge, sondern auch um Trainingsmöglichkeiten, kommende Turniere und das Vereinsleben bei den Schachfreunden Heilbronn-Biberach.
+
+## Fortsetzung geplant
+
+Der erste offene Vereinsabend wurde von den Teilnehmerinnen und Teilnehmern gut angenommen. Wegen der positiven Rückmeldungen soll das Format künftig regelmäßig stattfinden. Der nächste Termin wird rechtzeitig über den Vereinskalender und die Vereinskanäle bekannt gegeben.
+
+Wer den Verein kennenlernen oder einfach eine Partie Schach spielen möchte, ist zu den offenen Vereinsabenden herzlich willkommen.


### PR DESCRIPTION
Adds the new article `content/blog/article/20260806.offener-vereinsabend.md` about the first open club evening of the Schachfreunde HN-Biberach. No media assets were provided or added.